### PR TITLE
feat: add install-dev.sh for testing from source

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -24,8 +24,9 @@ info "Installing dependencies..."
 cd "$REPO_ROOT"
 bun install
 
-info "Building all packages..."
-bun run build
+info "Building core and CLI..."
+bun run --cwd packages/core build
+bun run --cwd packages/cli build
 
 # ── Link CLI globally ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `scripts/install-dev.sh` for building and linking the CLI from local source
- Covers the workflow: make changes → run script → test locally without publishing to npm
- Builds all packages, links CLI globally via `npm link`, then runs `tap install` for runtime setup

## Usage
```bash
./scripts/install-dev.sh
```

To revert to the npm version:
```bash
npm unlink -g trusted-agents-cli && npm i -g trusted-agents-cli
```

## Test plan
- [x] Ran `./scripts/install-dev.sh` from repo root — builds, links, and installs successfully
- [x] Verified `tap --version` resolves to local build
- [x] Verified `tap install` detects and configures available runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new developer-only shell script and does not change runtime/production application code. Main risk is minor developer environment disruption due to global `npm link`/`tap install` side effects.
> 
> **Overview**
> Adds `scripts/install-dev.sh`, a developer helper to test the CLI from local source without publishing.
> 
> The script checks Node 18+ and Bun, runs `bun install`, builds `packages/core` and `packages/cli`, globally links `trusted-agents-cli` via `npm link` (exposing `tap`), and finishes by running `tap install` with guidance to revert to the npm-installed version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6f01c54ba06fe52d8cae49c6a449e991ebc5d59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->