### PR TITLE
[codex] Update Tack production endpoint

### DIFF
--- a/packages/cli/src/lib/ipfs.ts
+++ b/packages/cli/src/lib/ipfs.ts
@@ -8,7 +8,7 @@ import { createExecutionEvmSigner, createSigningProviderViemAccount } from "trus
 
 const PINATA_X402_ENDPOINT = "https://402.pinata.cloud/v1/pin/public";
 const PINATA_API_ENDPOINT = "https://api.pinata.cloud/pinning/pinJSONToIPFS";
-export const DEFAULT_TACK_API_ENDPOINT = "https://tack-api-production.up.railway.app";
+export const DEFAULT_TACK_API_ENDPOINT = "https://tack.taiko.xyz";
 
 const IPFS_UPLOAD_PROVIDERS = ["auto", "x402", "pinata", "tack"] as const;
 

--- a/packages/cli/test/register-update.test.ts
+++ b/packages/cli/test/register-update.test.ts
@@ -301,6 +301,14 @@ describe("register update", () => {
 		expect(ipfsLib.uploadToIpfsTack).toHaveBeenCalledOnce();
 		expect(ipfsLib.uploadToIpfsX402).not.toHaveBeenCalled();
 		expect(executionLib.executeContractCalls).toHaveBeenCalledOnce();
+		expect(ipfsLib.uploadToIpfsTack).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({
+				apiUrl: "https://tack.taiko.xyz",
+			}),
+		);
 	});
 
 	it("honors explicit pinata provider when JWT is supplied", async () => {

--- a/skills/trusted-agents/SKILL.md
+++ b/skills/trusted-agents/SKILL.md
@@ -109,7 +109,7 @@ Your chain determines everything — registration chain, gas payment, and IPFS u
 | Chain | Fund with | Gas | IPFS upload |
 |---|---|---|---|
 | Base | ~0.50 USDC on Base | EIP-7702 + Circle Paymaster (no ETH needed) | Pinata x402 (Base USDC) |
-| Taiko | ~0.50 USDC on Taiko (to the Servo execution account) | EIP-4337 + Servo Paymaster (USDC only, no ETH needed) | Tack x402 (Taiko USDC) — endpoint: `https://tack-api-production.up.railway.app` |
+| Taiko | ~0.50 USDC on Taiko (to the Servo execution account) | EIP-4337 + Servo Paymaster (USDC only, no ETH needed) | Tack x402 (Taiko USDC) — endpoint: `https://tack.taiko.xyz/` |
 
 IPFS provider auto-selects based on chain. Override with `--ipfs-provider <auto|x402|pinata|tack>` if needed.
 


### PR DESCRIPTION
## Summary
- update the default Tack x402 upload endpoint to the new production URL `https://tack.taiko.xyz`
- add a register/update regression test that asserts the resolved default Tack API URL is passed into the upload flow
- refresh the TAP skill guidance for Taiko so the documented endpoint matches the CLI behavior

## Why
Issue #53 reported that the production Tack endpoint changed. The CLI still defaulted to the old Railway host, so Taiko IPFS uploads would target the wrong URL unless users overrode `ipfs.tackApiUrl` manually.

## Validation
- `bun run test packages/cli/test/ipfs.test.ts packages/cli/test/register-update.test.ts`
- `bun run --cwd packages/cli typecheck`
- `git diff --check`

Fixes #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single default URL for Tack uploads and adds a regression test plus docs alignment; primary risk is misconfiguration causing Taiko IPFS uploads to hit the wrong host.
> 
> **Overview**
> Updates the default Tack x402 upload base URL from the deprecated Railway host to **`https://tack.taiko.xyz`**, affecting Taiko IPFS uploads when no explicit `tackApiUrl` override is provided.
> 
> Adds a regression assertion in `register-update` tests to verify the resolved Tack `apiUrl` is passed into `uploadToIpfsTack`, and refreshes the Trusted Agents skill documentation so the Taiko endpoint matches CLI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 741d30361643da96b97911fdeaf076dd0fd6ac5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->