### PR TITLE
[codex] switch TAP to OWS passphrase signing

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -209,11 +209,11 @@ File: `packages/sdk/src/orchestrator.ts`
 
 1. One OWS wallet per agent (no raw private key):
 - Each agent identity is backed by an Open Wallet Service (OWS) wallet
-- A scoped API key authenticates CLI/SDK requests to OWS
-- All signing (ERC-8004 ownership, invite signing, XMTP identity) goes through OWS policy-gated signing
+- TAP unlocks the local OWS wallet with its configured passphrase
+- All signing (ERC-8004 ownership, invite signing, XMTP identity, EIP-712) goes through OWS native signing
 - The agent process never sees or stores a raw private key
-- Config stores `ows.wallet` (wallet ID) and `ows.api_key` (scoped API key)
-- Env overrides: `TAP_OWS_WALLET`, `TAP_OWS_API_KEY`
+- Config stores `ows.wallet` (wallet ID) and `ows.passphrase`
+- Env overrides: `TAP_OWS_WALLET`, `TAP_OWS_PASSPHRASE`
 
 2. XMTP DB encryption key:
 - New agents: derived from `signMessage("xmtp-db-encryption-key")` via OWS, then hashed
@@ -244,7 +244,7 @@ File: `packages/sdk/src/orchestrator.ts`
 9. **Config lives inside data-dir** — `--data-dir` (or `TAP_DATA_DIR`) is the single root for all per-agent state:
 ```
 <dataDir>/
-├── config.yaml              # agent_id, chain, xmtp.env, ows.wallet, ows.api_key, xmtp.db_encryption_key
+├── config.yaml              # agent_id, chain, xmtp.env, ows.wallet, ows.passphrase, xmtp.db_encryption_key
 ├── contacts.json            # Connected peers (trust store)
 ├── request-journal.json     # Durable TAP action request state
 ├── pending-connects.json    # Minimal outbound connection state awaiting connection/result
@@ -335,7 +335,7 @@ File: `packages/sdk/src/orchestrator.ts`
 - All signing goes through `SigningProvider` (backed by OWS), never raw private keys
 - If adding a new signing operation, wire it through the existing `SigningProvider` from context
 - Update OWS wallet provisioning tests if wallet creation flow changes
-- Keep `ows.wallet` and `ows.api_key` config fields in sync with env overrides (`TAP_OWS_WALLET`, `TAP_OWS_API_KEY`)
+- Keep `ows.wallet` and `ows.passphrase` config fields in sync with env overrides (`TAP_OWS_WALLET`, `TAP_OWS_PASSPHRASE`)
 
 ### Adding/changing/removing a CLI command
 - Update `skills/trusted-agents/SKILL.md` (the single unified skill). The OpenClaw plugin copies this file at build time, so both hosts update automatically.

--- a/LIVE_SMOKE_RUNBOOK.md
+++ b/LIVE_SMOKE_RUNBOOK.md
@@ -33,9 +33,9 @@ Use the full path when the agent wallets have a small amount of Base mainnet USD
 
 Required:
 - `TAP_SMOKE_AGENT_A_OWS_WALLET` — OWS wallet ID for Agent A
-- `TAP_SMOKE_AGENT_A_OWS_API_KEY` — OWS API key for Agent A
+- `TAP_SMOKE_AGENT_A_OWS_PASSPHRASE` — OWS wallet passphrase for Agent A
 - `TAP_SMOKE_AGENT_B_OWS_WALLET` — OWS wallet ID for Agent B
-- `TAP_SMOKE_AGENT_B_OWS_API_KEY` — OWS API key for Agent B
+- `TAP_SMOKE_AGENT_B_OWS_PASSPHRASE` — OWS wallet passphrase for Agent B
 
 Optional:
 - `TAP_PINATA_JWT`
@@ -43,7 +43,7 @@ Optional:
 Notes:
 - `TAP_PINATA_JWT` is not needed for the x402 path.
 - If you use `TAP_PINATA_JWT`, you are not testing x402 upload.
-- Do not commit OWS wallet IDs, API keys, or any funding mnemonic to the repository.
+- Do not commit OWS wallet IDs, passphrases, or any funding mnemonic to the repository.
 
 ## Basic Prerequisites
 
@@ -242,12 +242,12 @@ AGENT_B_DIR="$(mktemp -d /tmp/tap-live-b.XXXXXX)"
 
 ```bash
 tap --data-dir "$AGENT_A_DIR" init \
-  --ows-wallet "$TAP_SMOKE_AGENT_A_OWS_WALLET" \
-  --ows-api-key "$TAP_SMOKE_AGENT_A_OWS_API_KEY"
+  --wallet "$TAP_SMOKE_AGENT_A_OWS_WALLET" \
+  --passphrase "$TAP_SMOKE_AGENT_A_OWS_PASSPHRASE"
 
 tap --data-dir "$AGENT_B_DIR" init \
-  --ows-wallet "$TAP_SMOKE_AGENT_B_OWS_WALLET" \
-  --ows-api-key "$TAP_SMOKE_AGENT_B_OWS_API_KEY"
+  --wallet "$TAP_SMOKE_AGENT_B_OWS_WALLET" \
+  --passphrase "$TAP_SMOKE_AGENT_B_OWS_PASSPHRASE"
 ```
 
 ### 3. Resolve the two agent addresses
@@ -300,7 +300,7 @@ Continue with the shared live flow below.
 ### 1. Point at already-registered agent homes
 
 Use any two existing TAP data dirs that already contain:
-- a configured OWS wallet and API key
+- a configured OWS wallet and passphrase
 - the correct `agent_id`
 - a registration that resolves on-chain
 
@@ -488,13 +488,13 @@ Full-path-only extra pass criteria:
 - insufficient funds
   - top up the agent wallet before continuing
 - OWS signing errors
-  - verify `ows.wallet` and `ows.api_key` in the agent's config.yaml
-  - ensure OWS is reachable and the API key has not expired
+  - verify `ows.wallet` and `ows.passphrase` in the agent's config.yaml
+  - ensure OWS is reachable and the passphrase is correct
 
 ## Automation Guidance
 
 If this becomes automated later:
 - prefer `workflow_dispatch` or nightly cron
-- store all OWS wallet IDs and API keys in protected environment secrets
+- store all OWS wallet IDs and passphrases in protected environment secrets
 - add a funding verification step before the smoke flow
 - publish the tx hash, permissions snapshots, and ledger tails as workflow artifacts

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -104,7 +104,7 @@ Examples:
 		.description("First-time setup wizard")
 		.option("--chain <name>", "Chain to register on (alias or CAIP-2)")
 		.option("--wallet <name>", "Use an existing OWS wallet by name")
-		.option("--passphrase <passphrase>", "Wallet passphrase for API key creation")
+		.option("--passphrase <passphrase>", "OWS wallet passphrase")
 		.option("--non-interactive", "Skip prompts and use defaults")
 		.addHelpText(
 			"after",
@@ -135,7 +135,7 @@ ${chainAliasHelpText()}
 	program
 		.command("migrate-wallet")
 		.description("Migrate an existing agent from raw key file to OWS")
-		.option("--passphrase <passphrase>", "Wallet passphrase for import and API key creation")
+		.option("--passphrase <passphrase>", "OWS wallet passphrase for import")
 		.option("--non-interactive", "Skip prompts and use defaults")
 		.action(
 			async (cmdOpts: {

--- a/packages/cli/src/commands/config-show.ts
+++ b/packages/cli/src/commands/config-show.ts
@@ -12,7 +12,7 @@ export async function configShowCommand(opts: GlobalOptions): Promise<void> {
 		const legacyWarning = getLegacyWalletMigrationWarning({
 			dataDir: config.dataDir,
 			owsWallet: config.ows.wallet,
-			owsApiKey: config.ows.apiKey,
+			owsPassphrase: config.ows.passphrase,
 		});
 
 		const redacted = {
@@ -20,7 +20,7 @@ export async function configShowCommand(opts: GlobalOptions): Promise<void> {
 			chain: config.chain,
 			ows: {
 				wallet: config.ows.wallet,
-				api_key: config.ows.apiKey ? "***redacted***" : "",
+				passphrase: config.ows.passphrase ? "***redacted***" : "",
 			},
 			data_dir: config.dataDir,
 			invite_expiry_seconds: config.inviteExpirySeconds,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -13,12 +13,9 @@ import {
 import { errorCode, exitCodeForError } from "../lib/errors.js";
 import { error, info, success } from "../lib/output.js";
 import {
-	createOwsApiKey,
-	createOwsPolicy,
 	createOwsWallet,
 	deriveXmtpDbEncryptionKey,
 	ensureOwsInstalled,
-	findCompatiblePolicies,
 	listOwsWallets,
 } from "../lib/ows.js";
 import { promptInput } from "../lib/prompt.js";
@@ -28,7 +25,7 @@ export interface InitOptions {
 	chain?: string;
 	/** Pre-select wallet by name (non-interactive). */
 	wallet?: string;
-	/** Wallet passphrase for API key creation (non-interactive). */
+	/** OWS wallet passphrase (non-interactive). */
 	passphrase?: string;
 	/** Skip interactive prompts — use defaults. */
 	nonInteractive?: boolean;
@@ -53,7 +50,7 @@ export async function initCommand(opts: GlobalOptions, cmdOpts?: InitOptions): P
 		const existingConfig = existsSync(configPath)
 			? ((YAML.parse(await readFile(configPath, "utf-8")) as {
 					chain?: string;
-					ows?: { wallet?: string; api_key?: string };
+					ows?: { wallet?: string; passphrase?: string };
 					xmtp?: { db_encryption_key?: string };
 				} | null) ?? undefined)
 			: undefined;
@@ -67,7 +64,7 @@ export async function initCommand(opts: GlobalOptions, cmdOpts?: InitOptions): P
 
 		// OWS wallet setup — only when writing a new config
 		let owsWallet: string | undefined = existingConfig?.ows?.wallet;
-		let owsApiKey: string | undefined = existingConfig?.ows?.api_key;
+		let owsPassphrase: string | undefined = existingConfig?.ows?.passphrase;
 		let xmtpDbEncryptionKey: string | undefined = existingConfig?.xmtp?.db_encryption_key;
 
 		if (!existsSync(configPath)) {
@@ -76,21 +73,10 @@ export async function initCommand(opts: GlobalOptions, cmdOpts?: InitOptions): P
 
 			const walletSetup = await setupWallet(opts, cmdOpts);
 			owsWallet = walletSetup.walletName;
-
-			const policySetup = await setupPolicy(chain, opts, cmdOpts);
-			const policyId = policySetup.policyId;
-
-			const apiKeySetup = await setupApiKey(
-				owsWallet,
-				policyId,
-				walletSetup.passphrase,
-				opts,
-				cmdOpts,
-			);
-			owsApiKey = apiKeySetup.token;
+			owsPassphrase = walletSetup.passphrase;
 
 			// Derive XMTP DB encryption key
-			xmtpDbEncryptionKey = deriveXmtpDbEncryptionKey(owsWallet, chain, owsApiKey);
+			xmtpDbEncryptionKey = deriveXmtpDbEncryptionKey(owsWallet, chain, owsPassphrase);
 		}
 
 		// Write config file if it doesn't exist
@@ -113,10 +99,10 @@ export async function initCommand(opts: GlobalOptions, cmdOpts?: InitOptions): P
 				},
 			};
 
-			if (owsWallet && owsApiKey) {
+			if (owsWallet) {
 				yamlConfig.ows = {
 					wallet: owsWallet,
-					api_key: owsApiKey,
+					passphrase: owsPassphrase ?? "",
 				};
 			}
 
@@ -141,7 +127,7 @@ export async function initCommand(opts: GlobalOptions, cmdOpts?: InitOptions): P
 			nextSteps.push(`Wallet: ${owsWallet}`);
 		} else {
 			nextSteps.push("Configure OWS wallet: tap config set ows.wallet <wallet-name>");
-			nextSteps.push("Configure OWS API key: tap config set ows.api_key <api-key>");
+			nextSteps.push("Configure OWS passphrase: tap config set ows.passphrase <passphrase>");
 		}
 
 		nextSteps.push(
@@ -226,83 +212,4 @@ async function setupWallet(opts: GlobalOptions, cmdOpts?: InitOptions): Promise<
 	info(`Created wallet: ${created.name} (${created.address})`, opts);
 
 	return { walletName: created.name, passphrase };
-}
-
-// ─── Policy Setup ───────────────────────────────────────────────────────
-
-interface PolicySetupResult {
-	policyId: string;
-}
-
-async function setupPolicy(
-	chain: string,
-	opts: GlobalOptions,
-	cmdOpts?: InitOptions,
-): Promise<PolicySetupResult> {
-	// Build chain list: selected chain + Base mainnet for x402 if different
-	const policyChains = [chain];
-	if (chain !== "eip155:8453") {
-		policyChains.push("eip155:8453");
-	}
-
-	// Check for compatible existing policies
-	const compatible = findCompatiblePolicies(chain);
-
-	if (compatible.length > 0 && !cmdOpts?.nonInteractive) {
-		info("\nCompatible OWS policies:", opts);
-		for (let i = 0; i < compatible.length; i++) {
-			const p = compatible[i]!;
-			info(`  ${i + 1}. ${p.name} (chains: ${p.chains.join(", ")})`, opts);
-		}
-
-		const choice = await promptInput("\nReuse an existing policy? [1/2/.../no]: ");
-		if (choice && choice !== "no") {
-			const idx = Number.parseInt(choice, 10) - 1;
-			if (idx >= 0 && idx < compatible.length) {
-				const selected = compatible[idx]!;
-				info(`Using policy: ${selected.id}`, opts);
-				return { policyId: selected.id };
-			}
-		}
-	}
-
-	// Create new policy
-	const policyId = `tap-${randomBytes(4).toString("hex")}`;
-	const oneYearFromNow = new Date();
-	oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
-
-	createOwsPolicy({
-		id: policyId,
-		chains: policyChains,
-		expiresAt: oneYearFromNow.toISOString(),
-	});
-
-	info(`Created policy: ${policyId} (chains: ${policyChains.join(", ")})`, opts);
-	return { policyId };
-}
-
-// ─── API Key Setup ──────────────────────────────────────────────────────
-
-interface ApiKeySetupResult {
-	token: string;
-}
-
-async function setupApiKey(
-	walletName: string,
-	policyId: string,
-	passphrase: string,
-	opts: GlobalOptions,
-	_cmdOpts?: InitOptions,
-): Promise<ApiKeySetupResult> {
-	const keyName = `tap-${walletName}-${Date.now()}`;
-	const result = createOwsApiKey({
-		name: keyName,
-		walletName,
-		policyId,
-		passphrase,
-	});
-
-	info(`Created API key: ${keyName}`, opts);
-
-	return { token: result.token };
 }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -55,7 +55,7 @@ export async function installCommand(cmdOpts: InstallOptions, opts: GlobalOption
 			dataDir,
 			configPath,
 			owsWallet: process.env.TAP_OWS_WALLET,
-			owsApiKey: process.env.TAP_OWS_API_KEY,
+			owsPassphrase: process.env.TAP_OWS_PASSPHRASE,
 		});
 
 		for (const runtime of autoDetect ? SUPPORTED_RUNTIMES : runtimes) {

--- a/packages/cli/src/commands/migrate-wallet.ts
+++ b/packages/cli/src/commands/migrate-wallet.ts
@@ -8,15 +8,7 @@ import { resolveChainAlias } from "../lib/chains.js";
 import { resolveConfigPath, resolveDataDir } from "../lib/config-loader.js";
 import { errorCode, exitCodeForError } from "../lib/errors.js";
 import { error, info, success } from "../lib/output.js";
-import {
-	createOwsApiKey,
-	createOwsPolicy,
-	ensureOwsInstalled,
-	findCompatiblePolicies,
-	getOwsWalletAddress,
-	importOwsWalletPrivateKey,
-} from "../lib/ows.js";
-import { promptInput } from "../lib/prompt.js";
+import { ensureOwsInstalled, getOwsWalletAddress, importOwsWalletPrivateKey } from "../lib/ows.js";
 import type { GlobalOptions } from "../types.js";
 
 export interface MigrateWalletOptions {
@@ -45,8 +37,8 @@ export async function migrateWalletCommand(
 		const yaml = (YAML.parse(configContent) ?? {}) as Record<string, unknown>;
 
 		// Already migrated?
-		const existingOws = yaml.ows as { wallet?: string; api_key?: string } | undefined;
-		if (existingOws?.wallet && existingOws?.api_key) {
+		const existingOws = yaml.ows as { wallet?: string; passphrase?: string } | undefined;
+		if (existingOws?.wallet) {
 			throw new Error("This agent already has OWS wallet configuration. Migration is not needed.");
 		}
 
@@ -106,61 +98,7 @@ export async function migrateWalletCommand(
 			);
 		}
 
-		// ── Step 5: Policy setup ──────────────────────────────────────
-
-		const policyChains = [chain];
-		if (chain !== "eip155:8453") {
-			policyChains.push("eip155:8453");
-		}
-
-		let policyId: string;
-		const compatible = findCompatiblePolicies(chain);
-
-		if (compatible.length > 0 && !cmdOpts?.nonInteractive) {
-			info("\nCompatible OWS policies:", opts);
-			for (let i = 0; i < compatible.length; i++) {
-				const p = compatible[i]!;
-				info(`  ${i + 1}. ${p.name} (chains: ${p.chains.join(", ")})`, opts);
-			}
-
-			const choice = await promptInput("\nReuse an existing policy? [1/2/.../no]: ");
-			if (choice && choice !== "no") {
-				const idx = Number.parseInt(choice, 10) - 1;
-				if (idx >= 0 && idx < compatible.length) {
-					policyId = compatible[idx]!.id;
-					info(`Using policy: ${policyId}`, opts);
-				} else {
-					policyId = createNewPolicy(policyChains);
-					info(`Created policy: ${policyId}`, opts);
-				}
-			} else {
-				policyId = createNewPolicy(policyChains);
-				info(`Created policy: ${policyId}`, opts);
-			}
-		} else {
-			// Non-interactive or no compatible policies
-			if (compatible.length > 0) {
-				// Non-interactive: reuse first compatible
-				policyId = compatible[0]!.id;
-				info(`Using existing policy: ${policyId}`, opts);
-			} else {
-				policyId = createNewPolicy(policyChains);
-				info(`Created policy: ${policyId}`, opts);
-			}
-		}
-
-		// ── Step 6: Create API key ────────────────────────────────────
-
-		const keyName = `tap-${walletName}-${Date.now()}`;
-		const apiKeyResult = createOwsApiKey({
-			name: keyName,
-			walletName,
-			policyId,
-			passphrase,
-		});
-		info(`Created API key: ${keyName}`, opts);
-
-		// ── Step 7: Verify signing works via OWS ──────────────────────
+		// ── Step 5: Verify signing works via OWS ──────────────────────
 
 		const owsAddress = getOwsWalletAddress(walletName);
 		if (owsAddress.toLowerCase() !== originalAddress.toLowerCase()) {
@@ -169,11 +107,11 @@ export async function migrateWalletCommand(
 			);
 		}
 
-		// ── Step 8: Update config.yaml ────────────────────────────────
+		// ── Step 6: Update config.yaml ────────────────────────────────
 
 		yaml.ows = {
 			wallet: walletName,
-			api_key: apiKeyResult.token,
+			passphrase,
 		};
 
 		const existingXmtp = (yaml.xmtp ?? {}) as Record<string, unknown>;
@@ -185,7 +123,7 @@ export async function migrateWalletCommand(
 		await writeFile(configPath, YAML.stringify(yaml), "utf-8");
 		info(`Updated config at ${configPath}`, opts);
 
-		// ── Step 9: Delete raw key file ───────────────────────────────
+		// ── Step 7: Delete raw key file ───────────────────────────────
 
 		await unlink(keyPath);
 		info("Deleted raw key file.", opts);
@@ -206,18 +144,4 @@ export async function migrateWalletCommand(
 		error(errorCode(err), err instanceof Error ? err.message : String(err), opts);
 		process.exitCode = exitCodeForError(err);
 	}
-}
-
-function createNewPolicy(chains: string[]): string {
-	const policyId = `tap-${randomBytes(4).toString("hex")}`;
-	const oneYearFromNow = new Date();
-	oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
-
-	createOwsPolicy({
-		id: policyId,
-		chains,
-		expiresAt: oneYearFromNow.toISOString(),
-	});
-
-	return policyId;
 }

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -574,9 +574,11 @@ async function readAgentAddress(dataDir: string): Promise<[string | null, string
 	try {
 		const raw = await readFile(configPath, "utf-8");
 		const parsed =
-			(YAML.parse(raw) as { ows?: { wallet?: string; api_key?: string }; chain?: string } | null) ??
-			undefined;
-		if (!parsed?.ows?.wallet || !parsed?.ows?.api_key) {
+			(YAML.parse(raw) as {
+				ows?: { wallet?: string; passphrase?: string };
+				chain?: string;
+			} | null) ?? undefined;
+		if (!parsed?.ows?.wallet) {
 			const legacyWarning = getLegacyWalletMigrationWarning({ dataDir, configPath });
 			return [null, legacyWarning ?? "OWS wallet config is missing from config.yaml."];
 		}
@@ -584,7 +586,7 @@ async function readAgentAddress(dataDir: string): Promise<[string | null, string
 		const provider = createConfiguredSigningProvider(
 			{
 				chain,
-				ows: { wallet: parsed.ows.wallet, apiKey: parsed.ows.api_key },
+				ows: { wallet: parsed.ows.wallet, passphrase: parsed.ows.passphrase ?? "" },
 				dataDir,
 			},
 			chain,

--- a/packages/cli/src/lib/config-loader.ts
+++ b/packages/cli/src/lib/config-loader.ts
@@ -51,7 +51,7 @@ export async function loadConfig(
 		(!existsSync(configPath) ? DEFAULT_CHAIN_ALIAS : undefined);
 	const chain = chainRaw ? resolveChainAlias(chainRaw) : undefined;
 	const owsWallet = process.env.TAP_OWS_WALLET;
-	const owsApiKey = process.env.TAP_OWS_API_KEY;
+	const owsPassphrase = process.env.TAP_OWS_PASSPHRASE;
 	const executionMode = process.env.TAP_EXECUTION_MODE as ExecutionMode | undefined;
 	const paymasterProvider = process.env.TAP_PAYMASTER_PROVIDER as
 		| ExecutionPaymasterProvider
@@ -63,7 +63,7 @@ export async function loadConfig(
 		agentId,
 		chain,
 		owsWallet,
-		owsApiKey,
+		owsPassphrase,
 		configPath,
 		extraChains: ALL_CHAINS,
 		executionMode,

--- a/packages/cli/src/lib/ows.ts
+++ b/packages/cli/src/lib/ows.ts
@@ -1,14 +1,11 @@
 import {
-	createApiKey,
-	createPolicy,
 	createWallet,
 	getWallet,
 	importWalletPrivateKey,
-	listPolicies,
 	listWallets,
 	signMessage,
 } from "@open-wallet-standard/core";
-import type { ApiKeyResult, WalletInfo } from "@open-wallet-standard/core";
+import type { WalletInfo } from "@open-wallet-standard/core";
 import { keccak256, toHex } from "viem";
 
 export interface OwsWalletEntry {
@@ -108,93 +105,19 @@ export function getOwsWalletAddress(nameOrId: string): string {
 	return address;
 }
 
-export interface CreatePolicyOptions {
-	id: string;
-	chains: string[];
-	expiresAt: string;
-}
-
-/**
- * Create an OWS policy with the given allowed chains and expiry.
- * Returns the policy ID.
- */
-export function createOwsPolicy(opts: CreatePolicyOptions): string {
-	const policyJson = JSON.stringify({
-		id: opts.id,
-		name: `tap-${opts.id}`,
-		version: 1,
-		created_at: new Date().toISOString(),
-		expires_at: opts.expiresAt,
-		rules: [{ type: "allowed_chains", chain_ids: opts.chains }],
-		action: "deny",
-	});
-	createPolicy(policyJson);
-	return opts.id;
-}
-
-export interface CompatiblePolicy {
-	id: string;
-	name: string;
-	chains: string[];
-	expiresAt?: string;
-}
-
-/**
- * Find policies that include the given chain in their allowed_chains rules.
- */
-export function findCompatiblePolicies(chain: string): CompatiblePolicy[] {
-	const policies = listPolicies();
-	const compatible: CompatiblePolicy[] = [];
-	for (const p of policies) {
-		const rules = p?.rules;
-		if (!Array.isArray(rules)) continue;
-		for (const rule of rules) {
-			if (
-				rule?.type === "allowed_chains" &&
-				Array.isArray(rule.chain_ids) &&
-				rule.chain_ids.includes(chain)
-			) {
-				compatible.push({
-					id: p.id ?? String(p.name),
-					name: p.name ?? p.id ?? "unknown",
-					chains: rule.chain_ids as string[],
-					expiresAt: p.expires_at,
-				});
-				break;
-			}
-		}
-	}
-	return compatible;
-}
-
-export interface CreateApiKeyOptions {
-	name: string;
-	walletName: string;
-	policyId: string;
-	passphrase: string;
-}
-
-/**
- * Create an OWS API key for the given wallet and policy.
- * Returns the raw token (ows_key_...) and key metadata.
- */
-export function createOwsApiKey(opts: CreateApiKeyOptions): ApiKeyResult {
-	return createApiKey(opts.name, [opts.walletName], [opts.policyId], opts.passphrase);
-}
-
 /**
  * Derive a deterministic XMTP DB encryption key by signing a fixed message
  * with the OWS wallet and hashing the signature.
  *
  * This produces a stable 32-byte key that survives restarts without storing
- * additional secrets — only the wallet + API key are needed.
+ * additional secrets — only the wallet + passphrase are needed.
  */
 export function deriveXmtpDbEncryptionKey(
 	walletName: string,
 	chain: string,
-	apiKey: string,
+	passphrase: string,
 ): `0x${string}` {
-	const result = signMessage(walletName, chain, "xmtp-db-encryption-key", apiKey);
+	const result = signMessage(walletName, chain, "xmtp-db-encryption-key", passphrase);
 	return keccak256(toHex(result.signature));
 }
 

--- a/packages/cli/src/lib/wallet-config.ts
+++ b/packages/cli/src/lib/wallet-config.ts
@@ -6,7 +6,7 @@ import YAML from "yaml";
 interface StoredWalletConfig {
 	ows?: {
 		wallet?: string;
-		api_key?: string;
+		passphrase?: string;
 	};
 }
 
@@ -14,7 +14,7 @@ interface WalletConfigStatusOptions {
 	dataDir: string;
 	configPath?: string;
 	owsWallet?: string;
-	owsApiKey?: string;
+	owsPassphrase?: string;
 }
 
 type WalletBackedConfig = Pick<TrustedAgentsConfig, "dataDir" | "chain" | "ows">;
@@ -35,14 +35,14 @@ function loadStoredWalletConfig(configPath: string): StoredWalletConfig | undefi
 
 function resolveEffectiveOwsConfig(options: WalletConfigStatusOptions): {
 	wallet: string;
-	apiKey: string;
+	passphrase: string;
 } {
 	const configPath = options.configPath ?? join(options.dataDir, "config.yaml");
 	const stored = loadStoredWalletConfig(configPath);
 
 	return {
 		wallet: options.owsWallet ?? stored?.ows?.wallet ?? "",
-		apiKey: options.owsApiKey ?? stored?.ows?.api_key ?? "",
+		passphrase: options.owsPassphrase ?? stored?.ows?.passphrase ?? "",
 	};
 }
 
@@ -50,7 +50,7 @@ export function getLegacyWalletMigrationWarning(
 	options: WalletConfigStatusOptions,
 ): string | undefined {
 	const effective = resolveEffectiveOwsConfig(options);
-	if (effective.wallet && effective.apiKey) {
+	if (effective.wallet) {
 		return undefined;
 	}
 
@@ -63,21 +63,21 @@ export function getLegacyWalletMigrationWarning(
 }
 
 function assertWalletConfigured(config: WalletBackedConfig): void {
-	if (config.ows.wallet && config.ows.apiKey) {
+	if (config.ows.wallet) {
 		return;
 	}
 
 	const legacyWarning = getLegacyWalletMigrationWarning({
 		dataDir: config.dataDir,
 		owsWallet: config.ows.wallet,
-		owsApiKey: config.ows.apiKey,
+		owsPassphrase: config.ows.passphrase,
 	});
 	if (legacyWarning) {
 		throw new ConfigError(legacyWarning);
 	}
 
 	throw new ConfigError(
-		"OWS wallet config is missing for this agent. Run `tap init` to create an OWS wallet and API key.",
+		"OWS wallet config is missing for this agent. Run `tap init` to create an OWS wallet and set its passphrase.",
 	);
 }
 
@@ -86,5 +86,5 @@ export function createConfiguredSigningProvider(
 	chain = config.chain,
 ): OwsSigningProvider {
 	assertWalletConfigured(config);
-	return new OwsSigningProvider(config.ows.wallet, chain, config.ows.apiKey);
+	return new OwsSigningProvider(config.ows.wallet, chain, config.ows.passphrase);
 }

--- a/packages/cli/test/balance.test.ts
+++ b/packages/cli/test/balance.test.ts
@@ -37,7 +37,7 @@ describe("tap balance", () => {
 		return {
 			agentId: -1,
 			chain: "eip155:8453",
-			ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+			ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 			dataDir: "/tmp/tap",
 			chains: {
 				"eip155:8453": {

--- a/packages/cli/test/config-loader.test.ts
+++ b/packages/cli/test/config-loader.test.ts
@@ -21,7 +21,7 @@ describe("config-loader", () => {
 		unsetEnv("TAP_AGENT_ID");
 		unsetEnv("TAP_CHAIN");
 		unsetEnv("TAP_OWS_WALLET");
-		unsetEnv("TAP_OWS_API_KEY");
+		unsetEnv("TAP_OWS_PASSPHRASE");
 		unsetEnv("TAP_RPC_URL");
 		unsetEnv("TAP_EXECUTION_MODE");
 		unsetEnv("TAP_PAYMASTER_PROVIDER");

--- a/packages/cli/test/config-show.test.ts
+++ b/packages/cli/test/config-show.test.ts
@@ -50,7 +50,7 @@ describe("tap config show", () => {
 		const config: TrustedAgentsConfig = {
 			agentId: 11,
 			chain: "eip155:8453",
-			ows: { wallet: "", apiKey: "" },
+			ows: { wallet: "", passphrase: "" },
 			dataDir,
 			chains: {
 				"eip155:8453": {
@@ -77,10 +77,10 @@ describe("tap config show", () => {
 
 		const output = JSON.parse(stdoutWrites.join("")) as {
 			status: string;
-			data?: { ows?: { wallet?: string; api_key?: string }; warnings?: string[] };
+			data?: { ows?: { wallet?: string; passphrase?: string }; warnings?: string[] };
 		};
 		expect(output.status).toBe("ok");
-		expect(output.data?.ows).toEqual({ wallet: "", api_key: "" });
+		expect(output.data?.ows).toEqual({ wallet: "", passphrase: "" });
 		expect(output.data?.warnings).toEqual([expect.stringContaining("tap migrate-wallet")]);
 		expect(stderrWrites).toEqual([]);
 	});
@@ -95,7 +95,7 @@ describe("tap config show", () => {
 				"chain: eip155:8453",
 				"ows:",
 				"  wallet: demo-wallet",
-				"  api_key: demo-key",
+				"  passphrase: demo-passphrase",
 			].join("\n"),
 			"utf-8",
 		);
@@ -104,13 +104,13 @@ describe("tap config show", () => {
 
 		const output = JSON.parse(stdoutWrites.join("")) as {
 			status: string;
-			data?: { agent_id?: number; ows?: { wallet?: string; api_key?: string } };
+			data?: { agent_id?: number; ows?: { wallet?: string; passphrase?: string } };
 		};
 		expect(output.status).toBe("ok");
 		expect(output.data?.agent_id).toBe(-1);
 		expect(output.data?.ows).toEqual({
 			wallet: "demo-wallet",
-			api_key: "***redacted***",
+			passphrase: "***redacted***",
 		});
 	});
 });

--- a/packages/cli/test/contacts-list.test.ts
+++ b/packages/cli/test/contacts-list.test.ts
@@ -45,7 +45,7 @@ describe("tap contacts list", () => {
 				"chain: eip155:8453",
 				"ows:",
 				"  wallet: demo-wallet",
-				"  api_key: demo-key",
+				"  passphrase: demo-passphrase",
 			].join("\n"),
 			"utf-8",
 		);

--- a/packages/cli/test/e2e-two-agent-flow.test.ts
+++ b/packages/cli/test/e2e-two-agent-flow.test.ts
@@ -826,7 +826,7 @@ async function waitForCondition<T>(
 async function setOwsConfig(
 	dataDir: string,
 	walletName: string,
-	apiKey: string,
+	passphrase: string,
 	agentId: number,
 ): Promise<void> {
 	const configPath = join(dataDir, "config.yaml");
@@ -834,6 +834,6 @@ async function setOwsConfig(
 	const content = await readFile(configPath, "utf-8");
 	const yaml = YAML.parse(content) as Record<string, unknown>;
 	yaml.agent_id = agentId;
-	yaml.ows = { wallet: walletName, api_key: apiKey };
+	yaml.ows = { wallet: walletName, passphrase };
 	await writeFile(configPath, YAML.stringify(yaml), "utf-8");
 }

--- a/packages/cli/test/execution.test.ts
+++ b/packages/cli/test/execution.test.ts
@@ -27,7 +27,7 @@ vi.mock("trusted-agents-core", async () => {
 const config = {
 	agentId: 1,
 	chain: "eip155:8453",
-	ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+	ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 	dataDir: "/tmp/tap",
 	chains: {
 		"eip155:8453": {

--- a/packages/cli/test/identity-resolve.test.ts
+++ b/packages/cli/test/identity-resolve.test.ts
@@ -28,7 +28,7 @@ describe("identity resolve", () => {
 		const config: TrustedAgentsConfig = {
 			agentId: 42,
 			chain: "eip155:8453",
-			ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+			ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 			dataDir: "/tmp/tap",
 			chains: {
 				"eip155:8453": {

--- a/packages/cli/test/identity-show.test.ts
+++ b/packages/cli/test/identity-show.test.ts
@@ -39,7 +39,7 @@ describe("tap identity show", () => {
 	const config: TrustedAgentsConfig = {
 		agentId: -1,
 		chain: "eip155:8453",
-		ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+		ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 		dataDir: "/tmp/tap",
 		chains: {
 			"eip155:8453": {
@@ -125,7 +125,7 @@ describe("tap identity show", () => {
 			...config,
 			agentId: 11,
 			dataDir,
-			ows: { wallet: "", apiKey: "" },
+			ows: { wallet: "", passphrase: "" },
 		});
 
 		await identityShowCommand({ json: true });

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deletePolicy, deleteWallet, listApiKeys, revokeApiKey } from "@open-wallet-standard/core";
+import { deleteWallet } from "@open-wallet-standard/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import YAML from "yaml";
 import { initCommand } from "../src/commands/init.js";
@@ -18,8 +18,6 @@ describe("tap init", () => {
 
 	// Track OWS artifacts for cleanup
 	const createdWallets: string[] = [];
-	const createdPolicies: string[] = [];
-	const createdApiKeyIds: string[] = [];
 
 	beforeEach(async () => {
 		tmpDir = await mkdtemp(join(tmpdir(), "tap-init-test-"));
@@ -43,20 +41,6 @@ describe("tap init", () => {
 		process.stderr.write = origStderrWrite;
 
 		// Clean up OWS artifacts
-		for (const keyId of createdApiKeyIds) {
-			try {
-				revokeApiKey(keyId);
-			} catch (_) {
-				/* ignore */
-			}
-		}
-		for (const policyId of createdPolicies) {
-			try {
-				deletePolicy(policyId);
-			} catch (_) {
-				/* ignore */
-			}
-		}
 		for (const walletName of createdWallets) {
 			try {
 				deleteWallet(walletName);
@@ -64,8 +48,6 @@ describe("tap init", () => {
 				/* ignore */
 			}
 		}
-		createdApiKeyIds.length = 0;
-		createdPolicies.length = 0;
 		createdWallets.length = 0;
 
 		await rm(tmpDir, { recursive: true, force: true });
@@ -76,17 +58,6 @@ describe("tap init", () => {
 		const ows = yaml.ows as { wallet?: string } | undefined;
 		if (ows?.wallet) {
 			createdWallets.push(ows.wallet);
-		}
-		// Find API keys and policies created during the test
-		try {
-			const keys = listApiKeys();
-			for (const k of keys) {
-				if (k.name && typeof k.name === "string" && k.name.startsWith("tap-")) {
-					createdApiKeyIds.push(k.id);
-				}
-			}
-		} catch (_) {
-			/* ignore */
 		}
 	}
 
@@ -112,7 +83,7 @@ describe("tap init", () => {
 		// OWS config present
 		expect(yaml.ows).toBeDefined();
 		expect(yaml.ows.wallet).toBeTruthy();
-		expect(yaml.ows.api_key).toMatch(/^ows_key_/);
+		expect(yaml.ows.passphrase).toBe("");
 
 		// XMTP encryption key present
 		expect(yaml.xmtp).toBeDefined();
@@ -207,7 +178,7 @@ describe("tap init", () => {
 		const configContent = await readFile(join(dataDir, "config.yaml"), "utf-8");
 		const yaml = YAML.parse(configContent);
 		expect(yaml.ows.wallet).toBe(walletName);
-		expect(yaml.ows.api_key).toMatch(/^ows_key_/);
+		expect(yaml.ows.passphrase).toBe("test-pass");
 
 		trackOwsArtifacts(yaml);
 	});

--- a/packages/cli/test/migrate-wallet.test.ts
+++ b/packages/cli/test/migrate-wallet.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deletePolicy, deleteWallet, listApiKeys, revokeApiKey } from "@open-wallet-standard/core";
+import { deleteWallet } from "@open-wallet-standard/core";
 import { keccak256, toHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -26,8 +26,6 @@ describe("tap migrate-wallet", () => {
 
 	// Track OWS artifacts for cleanup
 	const createdWallets: string[] = [];
-	const createdPolicies: string[] = [];
-	const createdApiKeyIds: string[] = [];
 
 	beforeEach(async () => {
 		tmpDir = await mkdtemp(join(tmpdir(), "tap-migrate-test-"));
@@ -54,20 +52,6 @@ describe("tap migrate-wallet", () => {
 		process.stderr.write = origStderrWrite;
 
 		// Clean up OWS artifacts
-		for (const keyId of createdApiKeyIds) {
-			try {
-				revokeApiKey(keyId);
-			} catch (_) {
-				/* ignore */
-			}
-		}
-		for (const policyId of createdPolicies) {
-			try {
-				deletePolicy(policyId);
-			} catch (_) {
-				/* ignore */
-			}
-		}
 		for (const walletName of createdWallets) {
 			try {
 				deleteWallet(walletName);
@@ -75,8 +59,6 @@ describe("tap migrate-wallet", () => {
 				/* ignore */
 			}
 		}
-		createdApiKeyIds.length = 0;
-		createdPolicies.length = 0;
 		createdWallets.length = 0;
 
 		await rm(tmpDir, { recursive: true, force: true });
@@ -86,16 +68,6 @@ describe("tap migrate-wallet", () => {
 		const ows = yaml.ows as { wallet?: string } | undefined;
 		if (ows?.wallet) {
 			createdWallets.push(ows.wallet);
-		}
-		try {
-			const keys = listApiKeys();
-			for (const k of keys) {
-				if (k.name && typeof k.name === "string" && k.name.startsWith("tap-")) {
-					createdApiKeyIds.push(k.id);
-				}
-			}
-		} catch (_) {
-			/* ignore */
 		}
 	}
 
@@ -123,7 +95,7 @@ describe("tap migrate-wallet", () => {
 		const updatedConfig = YAML.parse(await readFile(configPath, "utf-8"));
 		expect(updatedConfig.ows).toBeDefined();
 		expect(updatedConfig.ows.wallet).toBe("tap-agent-42");
-		expect(updatedConfig.ows.api_key).toMatch(/^ows_key_/);
+		expect(updatedConfig.ows.passphrase).toBe("");
 
 		// XMTP DB encryption key should be persisted (legacy formula)
 		expect(updatedConfig.xmtp).toBeDefined();
@@ -177,7 +149,7 @@ describe("tap migrate-wallet", () => {
 
 		// Add OWS block to config
 		const configContent = YAML.parse(await readFile(configPath, "utf-8"));
-		configContent.ows = { wallet: "existing-wallet", api_key: "ows_key_existing" };
+		configContent.ows = { wallet: "existing-wallet", passphrase: "existing-passphrase" };
 		await writeFile(configPath, YAML.stringify(configContent), "utf-8");
 
 		await migrateWalletCommand({ json: true, dataDir }, { nonInteractive: true });

--- a/packages/cli/test/ows.test.ts
+++ b/packages/cli/test/ows.test.ts
@@ -1,11 +1,8 @@
-import { createWallet, deletePolicy, deleteWallet, revokeApiKey } from "@open-wallet-standard/core";
+import { createWallet, deleteWallet } from "@open-wallet-standard/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-	createOwsApiKey,
-	createOwsPolicy,
 	createOwsWallet,
 	deriveXmtpDbEncryptionKey,
-	findCompatiblePolicies,
 	getOwsWalletAddress,
 	isOwsInstalled,
 	listOwsWallets,
@@ -13,10 +10,7 @@ import {
 
 const TEST_PREFIX = `ows-test-${Date.now()}`;
 const WALLET_NAME = `${TEST_PREFIX}-wallet`;
-const POLICY_ID = `${TEST_PREFIX}-policy`;
 const PASSPHRASE = "test-passphrase";
-
-let apiKeyId: string | undefined;
 
 describe("OWS helpers", () => {
 	beforeAll(() => {
@@ -26,18 +20,6 @@ describe("OWS helpers", () => {
 
 	afterAll(() => {
 		// Cleanup: best-effort removal of test artifacts
-		if (apiKeyId) {
-			try {
-				revokeApiKey(apiKeyId);
-			} catch (_) {
-				/* ignore */
-			}
-		}
-		try {
-			deletePolicy(POLICY_ID);
-		} catch (_) {
-			/* ignore */
-		}
 		try {
 			deleteWallet(WALLET_NAME);
 		} catch (_) {
@@ -90,72 +72,14 @@ describe("OWS helpers", () => {
 		});
 	});
 
-	describe("createOwsPolicy", () => {
-		it("creates a policy and returns the policy ID", () => {
-			const oneYear = new Date();
-			oneYear.setFullYear(oneYear.getFullYear() + 1);
-
-			const id = createOwsPolicy({
-				id: POLICY_ID,
-				chains: ["eip155:8453"],
-				expiresAt: oneYear.toISOString(),
-			});
-			expect(id).toBe(POLICY_ID);
-		});
-	});
-
-	describe("findCompatiblePolicies", () => {
-		it("finds the test policy for eip155:8453", () => {
-			const policies = findCompatiblePolicies("eip155:8453");
-			const found = policies.find((p) => p.id === POLICY_ID);
-			expect(found).toBeDefined();
-			expect(found!.chains).toContain("eip155:8453");
-		});
-
-		it("returns empty for an unknown chain", () => {
-			const policies = findCompatiblePolicies("eip155:999999");
-			const found = policies.find((p) => p.id === POLICY_ID);
-			expect(found).toBeUndefined();
-		});
-	});
-
-	describe("createOwsApiKey", () => {
-		it("creates an API key and returns a token starting with ows_key_", () => {
-			const result = createOwsApiKey({
-				name: `${TEST_PREFIX}-key`,
-				walletName: WALLET_NAME,
-				policyId: POLICY_ID,
-				passphrase: PASSPHRASE,
-			});
-			expect(result.token).toMatch(/^ows_key_/);
-			expect(result.id).toBeTruthy();
-			apiKeyId = result.id;
-		});
-	});
-
 	describe("deriveXmtpDbEncryptionKey", () => {
 		it("returns a 0x-prefixed 32-byte hex string", () => {
-			// Need an API key to sign
-			const keyResult = createOwsApiKey({
-				name: `${TEST_PREFIX}-derive-key`,
-				walletName: WALLET_NAME,
-				policyId: POLICY_ID,
-				passphrase: PASSPHRASE,
-			});
-
-			const key = deriveXmtpDbEncryptionKey(WALLET_NAME, "eip155:8453", keyResult.token);
+			const key = deriveXmtpDbEncryptionKey(WALLET_NAME, "eip155:8453", PASSPHRASE);
 			expect(key).toMatch(/^0x[0-9a-fA-F]{64}$/);
 
 			// Deterministic — same inputs produce same key
-			const key2 = deriveXmtpDbEncryptionKey(WALLET_NAME, "eip155:8453", keyResult.token);
+			const key2 = deriveXmtpDbEncryptionKey(WALLET_NAME, "eip155:8453", PASSPHRASE);
 			expect(key).toBe(key2);
-
-			// Cleanup
-			try {
-				revokeApiKey(keyResult.id);
-			} catch (_) {
-				/* ignore */
-			}
 		});
 	});
 });

--- a/packages/cli/test/register-update.test.ts
+++ b/packages/cli/test/register-update.test.ts
@@ -42,7 +42,7 @@ describe("register update", () => {
 		return {
 			agentId: 7,
 			chain: "eip155:8453",
-			ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+			ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 			dataDir: tmpDir,
 			chains: {
 				"eip155:8453": {

--- a/packages/cli/test/remove.test.ts
+++ b/packages/cli/test/remove.test.ts
@@ -48,7 +48,7 @@ describe("tap remove", () => {
 	let origStdinOnce: typeof process.stdin.once;
 	let origStdinSetEncoding: typeof process.stdin.setEncoding;
 	let origTapOwsWallet: string | undefined;
-	let origTapOwsApiKey: string | undefined;
+	let origTapOwsPassphrase: string | undefined;
 	let origTapChain: string | undefined;
 	let origTapRpcUrl: string | undefined;
 
@@ -62,7 +62,7 @@ describe("tap remove", () => {
 		origStdinOnce = process.stdin.once.bind(process.stdin);
 		origStdinSetEncoding = process.stdin.setEncoding.bind(process.stdin);
 		origTapOwsWallet = process.env.TAP_OWS_WALLET;
-		origTapOwsApiKey = process.env.TAP_OWS_API_KEY;
+		origTapOwsPassphrase = process.env.TAP_OWS_PASSPHRASE;
 		origTapChain = process.env.TAP_CHAIN;
 		origTapRpcUrl = process.env.TAP_RPC_URL;
 		process.stdout.write = ((chunk: string) => {
@@ -100,7 +100,7 @@ describe("tap remove", () => {
 		process.stdin.setEncoding = origStdinSetEncoding;
 		process.exitCode = undefined;
 		process.env.TAP_OWS_WALLET = origTapOwsWallet;
-		process.env.TAP_OWS_API_KEY = origTapOwsApiKey;
+		process.env.TAP_OWS_PASSPHRASE = origTapOwsPassphrase;
 		process.env.TAP_CHAIN = origTapChain;
 		process.env.TAP_RPC_URL = origTapRpcUrl;
 		vi.clearAllMocks();
@@ -345,7 +345,7 @@ describe("tap remove", () => {
 
 	it("probes balance from the target data dir instead of env overrides", async () => {
 		process.env.TAP_OWS_WALLET = "env-override-wallet";
-		process.env.TAP_OWS_API_KEY = "env-override-key";
+		process.env.TAP_OWS_PASSPHRASE = "env-override-passphrase";
 		process.env.TAP_CHAIN = "taiko";
 		const getBalance = vi.fn().mockResolvedValue(1n);
 		vi.spyOn(walletLib, "buildPublicClient").mockReturnValue({
@@ -382,7 +382,7 @@ describe("tap remove", () => {
 		const result = await removeCommandModule.transferRemainingNativeBalance(
 			{
 				config: {
-					ows: { wallet: "test-wallet", apiKey: "test-key" },
+					ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 					chain: "eip155:8453",
 				} as never,
 				chain: "eip155:8453",
@@ -410,7 +410,7 @@ async function seedAgentData(dataDir: string): Promise<void> {
 	await mkdir(join(dataDir, "xmtp"), { recursive: true });
 	await writeFile(
 		join(dataDir, "config.yaml"),
-		"agent_id: 42\nchain: eip155:8453\nows:\n  wallet: test-wallet\n  api_key: test-api-key\n",
+		"agent_id: 42\nchain: eip155:8453\nows:\n  wallet: test-wallet\n  passphrase: test-passphrase\n",
 		"utf-8",
 	);
 	await writeFile(join(dataDir, "contacts.json"), "[]\n", "utf-8");

--- a/packages/cli/test/transfer.test.ts
+++ b/packages/cli/test/transfer.test.ts
@@ -39,7 +39,7 @@ describe("tap transfer", () => {
 		return {
 			agentId: 42,
 			chain: "eip155:8453",
-			ows: { wallet: "test-wallet", apiKey: "test-api-key" },
+			ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 			dataDir: "/tmp/tap",
 			chains: {
 				"eip155:1": {

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -16,7 +16,7 @@ interface StoredYamlConfig {
 	chain?: string;
 	ows?: {
 		wallet?: string;
-		api_key?: string;
+		passphrase?: string;
 	};
 	execution?: {
 		mode?: ExecutionMode;
@@ -44,7 +44,7 @@ export interface LoadTrustedAgentConfigOptions {
 	agentId?: number;
 	chain?: string;
 	owsWallet?: string;
-	owsApiKey?: string;
+	owsPassphrase?: string;
 	configPath?: string;
 	extraChains?: Record<string, ChainConfig>;
 	executionMode?: ExecutionMode;
@@ -99,7 +99,7 @@ export async function loadTrustedAgentConfigFromDataDir(
 	}
 
 	const owsWallet = options.owsWallet ?? yaml?.ows?.wallet ?? "";
-	const owsApiKey = options.owsApiKey ?? yaml?.ows?.api_key ?? "";
+	const owsPassphrase = options.owsPassphrase ?? yaml?.ows?.passphrase ?? "";
 	const chain = options.chain ?? yaml?.chain ?? "eip155:8453";
 	const executionMode =
 		options.executionMode ?? yaml?.execution?.mode ?? getDefaultExecutionModeForChain(chain);
@@ -132,7 +132,7 @@ export async function loadTrustedAgentConfigFromDataDir(
 	return {
 		agentId: agentId ?? 0,
 		chain,
-		ows: { wallet: owsWallet, apiKey: owsApiKey },
+		ows: { wallet: owsWallet, passphrase: owsPassphrase },
 		dataDir: resolvedDataDir,
 		chains,
 		inviteExpirySeconds: yaml?.invite_expiry_seconds ?? DEFAULT_CONFIG.inviteExpirySeconds,

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -20,8 +20,8 @@ export function validateConfig(
 	if (!partial.ows?.wallet || typeof partial.ows.wallet !== "string") {
 		throw new ConfigError("ows.wallet is required and must be a non-empty string");
 	}
-	if (!partial.ows?.apiKey?.startsWith("ows_key_")) {
-		throw new ConfigError("ows.apiKey is required and must start with 'ows_key_'");
+	if (partial.ows?.passphrase !== undefined && typeof partial.ows.passphrase !== "string") {
+		throw new ConfigError("ows.passphrase must be a string");
 	}
 
 	const mergedChains = {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -23,7 +23,7 @@ export interface IpfsConfig {
 
 export interface OwsConfig {
 	wallet: string;
-	apiKey: string;
+	passphrase: string;
 }
 
 export interface TrustedAgentsConfig {

--- a/packages/core/src/runtime/execution.ts
+++ b/packages/core/src/runtime/execution.ts
@@ -87,6 +87,16 @@ async function resolveExecutionContext(
 		};
 	}
 
+	if (mode === "eip7702" && provider.supportsAuthorizationSignatures?.() === false) {
+		warnings.push(
+			`${chainConfig.name} EIP-7702 execution requires a signer that can produce raw authorization signatures; using eoa instead`,
+		);
+		return {
+			...baseContext,
+			mode: "eoa",
+		};
+	}
+
 	const paymasterProvider =
 		pinnedPreview?.paymasterProvider ??
 		resolvePaymasterProvider(config, chainConfig, mode, warnings);

--- a/packages/core/src/signing/ows-provider.ts
+++ b/packages/core/src/signing/ows-provider.ts
@@ -2,23 +2,18 @@ import {
 	getWallet as owsGetWallet,
 	signMessage as owsSignMessage,
 	signTransaction as owsSignTransaction,
+	signTypedData as owsSignTypedData,
 } from "@open-wallet-standard/core";
 import type { Hex, SignableMessage, TransactionSerializable } from "viem";
-import {
-	concatHex,
-	hashTypedData,
-	keccak256,
-	numberToHex,
-	serializeTransaction,
-	toHex,
-	toRlp,
-} from "viem";
+import { serializeTransaction, toHex } from "viem";
 import type {
 	AuthorizationParameters,
 	SignTypedDataParameters,
 	SignedAuthorization,
 	SigningProvider,
 } from "./provider.js";
+
+type TypedDataField = { name: string; type: string };
 
 function ensureHexPrefix(value: string): Hex {
 	if (value.startsWith("0x")) {
@@ -27,12 +22,50 @@ function ensureHexPrefix(value: string): Hex {
 	return `0x${value}` as Hex;
 }
 
+function inferDomainTypes(domain: Record<string, unknown>): TypedDataField[] {
+	const fields: TypedDataField[] = [];
+	if (domain.name !== undefined) fields.push({ name: "name", type: "string" });
+	if (domain.version !== undefined) fields.push({ name: "version", type: "string" });
+	if (domain.chainId !== undefined) fields.push({ name: "chainId", type: "uint256" });
+	if (domain.verifyingContract !== undefined) {
+		fields.push({ name: "verifyingContract", type: "address" });
+	}
+	if (domain.salt !== undefined) fields.push({ name: "salt", type: "bytes32" });
+	return fields;
+}
+
+function normalizeTypedDataForOws(value: SignTypedDataParameters): SignTypedDataParameters {
+	if ("EIP712Domain" in value.types) {
+		return value;
+	}
+
+	const domainTypes = inferDomainTypes(value.domain);
+	if (domainTypes.length === 0) {
+		return value;
+	}
+
+	return {
+		...value,
+		types: {
+			EIP712Domain: domainTypes,
+			...value.types,
+		},
+	};
+}
+
+function stringifyTypedData(value: SignTypedDataParameters): string {
+	const normalized = normalizeTypedDataForOws(value);
+	return JSON.stringify(normalized, (_key, item) =>
+		typeof item === "bigint" ? item.toString() : item,
+	);
+}
+
 /**
  * SigningProvider backed by Open Wallet Standard (OWS).
  *
  * Delegates all cryptographic operations to the OWS vault via its native SDK.
- * The `apiKey` is passed as the `passphrase` parameter to OWS signing functions,
- * which uses it for API-key-based authentication and policy enforcement.
+ * TAP unlocks the local OWS wallet with its passphrase so it can use the
+ * native signing primitives OWS exposes for the wallet.
  */
 export class OwsSigningProvider implements SigningProvider {
 	private cachedAddress: `0x${string}` | undefined;
@@ -40,7 +73,7 @@ export class OwsSigningProvider implements SigningProvider {
 	constructor(
 		private readonly walletName: string,
 		private readonly chain: string,
-		private readonly apiKey: string,
+		private readonly passphrase: string,
 	) {}
 
 	async getAddress(): Promise<`0x${string}`> {
@@ -80,26 +113,24 @@ export class OwsSigningProvider implements SigningProvider {
 			encoding = "hex";
 		}
 
-		const result = owsSignMessage(this.walletName, this.chain, messageStr, this.apiKey, encoding);
+		const result = owsSignMessage(
+			this.walletName,
+			this.chain,
+			messageStr,
+			this.passphrase,
+			encoding,
+		);
 
 		return ensureHexPrefix(result.signature);
 	}
 
 	async signTypedData(params: SignTypedDataParameters): Promise<Hex> {
-		const { domain, types, primaryType, message } = params;
-
-		// OWS does not support signTypedData via API key auth, so we compute
-		// the EIP-712 hash ourselves and sign the raw hash with signMessage.
-		const hash = hashTypedData({
-			domain: domain as Record<string, unknown>,
-			types: types as Record<string, unknown>,
-			primaryType,
-			message: message as Record<string, unknown>,
-		});
-
-		// Sign the raw 32-byte hash — strip 0x for OWS hex encoding
-		const result = owsSignMessage(this.walletName, this.chain, hash.slice(2), this.apiKey, "hex");
-
+		const result = owsSignTypedData(
+			this.walletName,
+			this.chain,
+			stringifyTypedData(params),
+			this.passphrase,
+		);
 		return ensureHexPrefix(result.signature);
 	}
 
@@ -108,13 +139,13 @@ export class OwsSigningProvider implements SigningProvider {
 		// Remove the 0x prefix — OWS expects raw hex
 		const txHex = serialized.slice(2);
 
-		const result = owsSignTransaction(this.walletName, this.chain, txHex, this.apiKey);
+		const result = owsSignTransaction(this.walletName, this.chain, txHex, this.passphrase);
 
 		return ensureHexPrefix(result.signature);
 	}
 
 	async signAuthorization(params: AuthorizationParameters): Promise<SignedAuthorization> {
-		const { contractAddress, chainId, nonce } = params;
+		const { chainId, nonce } = params;
 
 		if (chainId === undefined) {
 			throw new Error("chainId is required for signAuthorization");
@@ -123,45 +154,12 @@ export class OwsSigningProvider implements SigningProvider {
 			throw new Error("nonce is required for signAuthorization");
 		}
 
-		// EIP-7702 authorization hash:
-		// keccak256(0x05 || rlp([chain_id, address, nonce]))
-		const encoded = toRlp([numberToHex(chainId), contractAddress, numberToHex(nonce)]);
-		const authHash = keccak256(concatHex(["0x05", encoded]));
-
-		// Sign the raw hash using signMessage with hex encoding
-		// Strip 0x prefix — OWS expects raw hex
-		const result = owsSignMessage(
-			this.walletName,
-			this.chain,
-			authHash.slice(2),
-			this.apiKey,
-			"hex",
+		throw new Error(
+			`OWS wallet "${this.walletName}" does not support raw EIP-7702 authorization signing`,
 		);
+	}
 
-		const sig = ensureHexPrefix(result.signature);
-
-		// Parse r, s, v from the 65-byte signature
-		// Signature format: r (32 bytes) + s (32 bytes) + v (1 byte) = 65 bytes = 130 hex chars
-		const sigBytes = sig.slice(2); // remove 0x
-		if (sigBytes.length !== 130) {
-			throw new Error(
-				`Expected 65-byte signature (130 hex chars), got ${sigBytes.length} hex chars`,
-			);
-		}
-
-		const r = `0x${sigBytes.slice(0, 64)}` as Hex;
-		const s = `0x${sigBytes.slice(64, 128)}` as Hex;
-		const vByte = Number.parseInt(sigBytes.slice(128, 130), 16);
-		// Normalize v: if v is 0 or 1 (recovery id), convert to 27/28
-		const v = BigInt(vByte < 27 ? vByte + 27 : vByte);
-
-		return {
-			contractAddress,
-			chainId,
-			nonce,
-			r,
-			s,
-			v,
-		};
+	supportsAuthorizationSignatures(): boolean {
+		return false;
 	}
 }

--- a/packages/core/src/signing/provider.ts
+++ b/packages/core/src/signing/provider.ts
@@ -28,4 +28,5 @@ export interface SigningProvider {
 	signTypedData(params: SignTypedDataParameters): Promise<Hex>;
 	signTransaction(tx: TransactionSerializable): Promise<Hex>;
 	signAuthorization(params: AuthorizationParameters): Promise<SignedAuthorization>;
+	supportsAuthorizationSignatures?(): boolean;
 }

--- a/packages/core/test/signing/ows-provider.test.ts
+++ b/packages/core/test/signing/ows-provider.test.ts
@@ -1,53 +1,22 @@
 import {
-	createApiKey,
-	createPolicy,
 	createWallet,
-	deletePolicy,
 	deleteWallet,
-	revokeApiKey,
+	signTypedData as owsSignTypedData,
 } from "@open-wallet-standard/core";
+import { hashTypedData, recoverAddress } from "viem";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { OwsSigningProvider } from "../../src/signing/ows-provider.js";
 
 const WALLET_NAME = `tap-test-${Date.now()}`;
-const POLICY_ID = `test-policy-${Date.now()}`;
 const CHAIN = "eip155:8453";
 const PASSPHRASE = "test-passphrase";
-
-let apiKey: string;
-let keyId: string;
 
 describe("OwsSigningProvider", () => {
 	beforeAll(() => {
 		createWallet(WALLET_NAME, PASSPHRASE);
-
-		createPolicy(
-			JSON.stringify({
-				id: POLICY_ID,
-				name: "test-all",
-				version: 1,
-				created_at: new Date().toISOString(),
-				rules: [{ type: "allowed_chains", chain_ids: [CHAIN] }],
-				action: "deny",
-			}),
-		);
-
-		const result = createApiKey(`test-key-${Date.now()}`, [WALLET_NAME], [POLICY_ID], PASSPHRASE);
-		apiKey = result.token;
-		keyId = result.id;
 	});
 
 	afterAll(() => {
-		try {
-			revokeApiKey(keyId);
-		} catch (_) {
-			/* ignore cleanup errors */
-		}
-		try {
-			deletePolicy(POLICY_ID);
-		} catch (_) {
-			/* ignore cleanup errors */
-		}
 		try {
 			deleteWallet(WALLET_NAME);
 		} catch (_) {
@@ -56,20 +25,20 @@ describe("OwsSigningProvider", () => {
 	});
 
 	it("getAddress returns a valid EVM address", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const address = await provider.getAddress();
 		expect(address).toMatch(/^0x[0-9a-fA-F]{40}$/);
 	});
 
 	it("getAddress caches the result", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const addr1 = await provider.getAddress();
 		const addr2 = await provider.getAddress();
 		expect(addr1).toBe(addr2);
 	});
 
 	it("signMessage with a string returns a valid hex signature", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const sig = await provider.signMessage("hello world");
 		expect(sig).toMatch(/^0x[0-9a-fA-F]+$/);
 		// 65-byte ECDSA signature = 130 hex chars + 0x prefix
@@ -77,14 +46,14 @@ describe("OwsSigningProvider", () => {
 	});
 
 	it("signMessage is deterministic (RFC 6979)", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const sig1 = await provider.signMessage("deterministic-test");
 		const sig2 = await provider.signMessage("deterministic-test");
 		expect(sig1).toBe(sig2);
 	});
 
 	it("signMessage with raw Uint8Array works", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const raw = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]); // "hello"
 		const sig = await provider.signMessage({ raw });
 		expect(sig).toMatch(/^0x[0-9a-fA-F]+$/);
@@ -92,36 +61,175 @@ describe("OwsSigningProvider", () => {
 	});
 
 	it("signMessage with raw hex string works", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const sig = await provider.signMessage({ raw: "0x68656c6c6f" });
 		expect(sig).toMatch(/^0x[0-9a-fA-F]+$/);
 		expect(sig.length).toBe(132);
 	});
 
 	it("signTypedData returns a valid signature", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
-		const sig = await provider.signTypedData({
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
+		const typedData = {
 			domain: {
 				name: "Test",
 				version: "1",
 				chainId: 8453,
+				verifyingContract: "0x0000000000000000000000000000000000000001",
 			},
 			types: {
 				EIP712Domain: [
 					{ name: "name", type: "string" },
 					{ name: "version", type: "string" },
 					{ name: "chainId", type: "uint256" },
+					{ name: "verifyingContract", type: "address" },
 				],
+				Test: [{ name: "value", type: "uint256" }],
 			},
-			primaryType: "EIP712Domain",
-			message: {},
-		});
+			primaryType: "Test",
+			message: {
+				value: 1,
+			},
+		};
+		const sig = await provider.signTypedData(typedData);
 		expect(sig).toMatch(/^0x[0-9a-fA-F]+$/);
 		expect(sig.length).toBe(132);
+		const recovered = await recoverAddress({
+			hash: hashTypedData(typedData),
+			signature: sig,
+		});
+		expect(recovered.toLowerCase()).toBe((await provider.getAddress()).toLowerCase());
+	});
+
+	it("signTypedData delegates to OWS native typed-data signing", async () => {
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
+		const typedData = {
+			domain: {
+				name: "Test",
+				version: "1",
+				chainId: 8453,
+				verifyingContract: "0x0000000000000000000000000000000000000001",
+			},
+			types: {
+				EIP712Domain: [
+					{ name: "name", type: "string" },
+					{ name: "version", type: "string" },
+					{ name: "chainId", type: "uint256" },
+					{ name: "verifyingContract", type: "address" },
+				],
+				Test: [{ name: "value", type: "uint256" }],
+			},
+			primaryType: "Test",
+			message: {
+				value: 1,
+			},
+		};
+
+		const direct = owsSignTypedData(
+			WALLET_NAME,
+			CHAIN,
+			JSON.stringify(typedData),
+			PASSPHRASE,
+		).signature;
+		const providerSig = await provider.signTypedData(typedData);
+
+		expect(providerSig.toLowerCase()).toBe(`0x${direct}`.toLowerCase());
+	});
+
+	it("signTypedData serializes bigint fields for x402-style payloads", async () => {
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
+		const typedData = {
+			domain: {
+				name: "USD Coin",
+				version: "2",
+				chainId: 8453,
+				verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+			},
+			types: {
+				EIP712Domain: [
+					{ name: "name", type: "string" },
+					{ name: "version", type: "string" },
+					{ name: "chainId", type: "uint256" },
+					{ name: "verifyingContract", type: "address" },
+				],
+				TransferWithAuthorization: [
+					{ name: "from", type: "address" },
+					{ name: "to", type: "address" },
+					{ name: "value", type: "uint256" },
+					{ name: "validAfter", type: "uint256" },
+					{ name: "validBefore", type: "uint256" },
+					{ name: "nonce", type: "bytes32" },
+				],
+			},
+			primaryType: "TransferWithAuthorization",
+			message: {
+				from: "0x0000000000000000000000000000000000000001",
+				to: "0x0000000000000000000000000000000000000002",
+				value: 1n,
+				validAfter: 0n,
+				validBefore: 9999999999n,
+				nonce: `0x${"11".repeat(32)}`,
+			},
+		};
+
+		const sig = await provider.signTypedData(typedData);
+		const recovered = await recoverAddress({
+			hash: hashTypedData(typedData),
+			signature: sig,
+		});
+		expect(recovered.toLowerCase()).toBe((await provider.getAddress()).toLowerCase());
+	});
+
+	it("signTypedData injects EIP712Domain when callers omit it", async () => {
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
+		const typedData = {
+			domain: {
+				name: "USD Coin",
+				version: "2",
+				chainId: 8453,
+				verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+			},
+			types: {
+				TransferWithAuthorization: [
+					{ name: "from", type: "address" },
+					{ name: "to", type: "address" },
+					{ name: "value", type: "uint256" },
+					{ name: "validAfter", type: "uint256" },
+					{ name: "validBefore", type: "uint256" },
+					{ name: "nonce", type: "bytes32" },
+				],
+			},
+			primaryType: "TransferWithAuthorization",
+			message: {
+				from: await provider.getAddress(),
+				to: "0x0000000000000000000000000000000000000002",
+				value: 1n,
+				validAfter: 0n,
+				validBefore: 9999999999n,
+				nonce: `0x${"22".repeat(32)}`,
+			},
+		};
+
+		const sig = await provider.signTypedData(typedData);
+		const recovered = await recoverAddress({
+			hash: hashTypedData({
+				...typedData,
+				types: {
+					EIP712Domain: [
+						{ name: "name", type: "string" },
+						{ name: "version", type: "string" },
+						{ name: "chainId", type: "uint256" },
+						{ name: "verifyingContract", type: "address" },
+					],
+					...typedData.types,
+				},
+			}),
+			signature: sig,
+		});
+		expect(recovered.toLowerCase()).toBe((await provider.getAddress()).toLowerCase());
 	});
 
 	it("signTransaction returns a valid signature", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		const sig = await provider.signTransaction({
 			to: "0x0000000000000000000000000000000000000001",
 			value: 0n,
@@ -135,23 +243,20 @@ describe("OwsSigningProvider", () => {
 		expect(sig).toMatch(/^0x[0-9a-fA-F]+$/);
 	});
 
-	it("signAuthorization returns a valid signed authorization", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
-		const auth = await provider.signAuthorization({
-			contractAddress: "0x0000000000000000000000000000000000000001",
-			chainId: 8453,
-			nonce: 0,
-		});
-		expect(auth.contractAddress).toBe("0x0000000000000000000000000000000000000001");
-		expect(auth.chainId).toBe(8453);
-		expect(auth.nonce).toBe(0);
-		expect(auth.r).toMatch(/^0x[0-9a-fA-F]{64}$/);
-		expect(auth.s).toMatch(/^0x[0-9a-fA-F]{64}$/);
-		expect(auth.v === 27n || auth.v === 28n).toBe(true);
+	it("reports authorization signatures as unsupported", async () => {
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
+		expect(provider.supportsAuthorizationSignatures()).toBe(false);
+		await expect(
+			provider.signAuthorization({
+				contractAddress: "0x0000000000000000000000000000000000000001",
+				chainId: 8453,
+				nonce: 0,
+			}),
+		).rejects.toThrow("does not support raw EIP-7702 authorization signing");
 	});
 
 	it("signAuthorization throws if chainId is missing", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		await expect(
 			provider.signAuthorization({
 				contractAddress: "0x0000000000000000000000000000000000000001",
@@ -160,7 +265,7 @@ describe("OwsSigningProvider", () => {
 	});
 
 	it("signAuthorization throws if nonce is missing", async () => {
-		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, PASSPHRASE);
 		await expect(
 			provider.signAuthorization({
 				contractAddress: "0x0000000000000000000000000000000000000001",
@@ -171,7 +276,7 @@ describe("OwsSigningProvider", () => {
 
 	it("getAddress throws for wallet with no EVM account", async () => {
 		// This test uses a non-existent wallet to trigger the error path
-		const provider = new OwsSigningProvider("nonexistent-wallet-xyz", CHAIN, apiKey);
+		const provider = new OwsSigningProvider("nonexistent-wallet-xyz", CHAIN, PASSPHRASE);
 		await expect(provider.getAddress()).rejects.toThrow();
 	});
 });

--- a/packages/core/test/unit/runtime/execution.test.ts
+++ b/packages/core/test/unit/runtime/execution.test.ts
@@ -100,7 +100,7 @@ function buildConfig(
 	return {
 		agentId: 1,
 		chain,
-		ows: { wallet: "test", apiKey: "ows_key_test" },
+		ows: { wallet: "test", passphrase: "test-passphrase" },
 		dataDir: "/tmp/tap",
 		chains: chainMap,
 		inviteExpirySeconds: 3600,
@@ -197,6 +197,57 @@ describe("execution", () => {
 		expect(preview.executionAddress).toBe(OWNER_ADDRESS);
 		expect(preview.paymasterProvider).toBe("circle");
 		expect(toSimple7702SmartAccount).toHaveBeenCalledOnce();
+	});
+
+	it("falls back to eoa on Base when the signer cannot produce 7702 authorizations", async () => {
+		const sendTransaction = vi.fn().mockResolvedValue("0xtxhash");
+		const waitForTransactionReceipt = vi.fn().mockResolvedValue({
+			status: "success",
+			transactionHash: "0xtxhash",
+			logs: [],
+		});
+		buildChainPublicClient.mockReturnValue({
+			readContract: vi.fn(),
+			verifyTypedData: vi.fn(),
+			waitForTransactionReceipt,
+		});
+		buildChainWalletClient.mockReturnValue({
+			chain: { id: 8453, name: "Base" },
+			sendTransaction,
+		});
+
+		const { executeContractCalls, getExecutionPreview } = await import(
+			"../../../src/runtime/execution.js"
+		);
+		const config = buildConfig("eip155:8453", {
+			mode: "eip7702",
+			paymasterProvider: "circle",
+		});
+		const provider = {
+			...TEST_PROVIDER,
+			supportsAuthorizationSignatures: () => false,
+		} as SigningProvider;
+
+		const preview = await getExecutionPreview(config, config.chains[config.chain]!, provider);
+		expect(preview.mode).toBe("eoa");
+		expect(preview.paymasterProvider).toBeUndefined();
+		expect(preview.warnings).toContain(
+			"Base EIP-7702 execution requires a signer that can produce raw authorization signatures; using eoa instead",
+		);
+
+		const result = await executeContractCalls(config, config.chains[config.chain]!, provider, [
+			{
+				to: "0x3000000000000000000000000000000000000003",
+				data: "0x",
+			},
+		]);
+
+		expect(result.mode).toBe("eoa");
+		expect(result.gasPaymentMode).toBe("native");
+		expect(sendTransaction).toHaveBeenCalledOnce();
+		expect(waitForTransactionReceipt).toHaveBeenCalledOnce();
+		expect(signAuthorization).not.toHaveBeenCalled();
+		expect(toSimple7702SmartAccount).not.toHaveBeenCalled();
 	});
 
 	it("coerces Base eip4337 requests back to an eip7702-compatible paymaster", async () => {

--- a/packages/core/test/unit/runtime/service.test.ts
+++ b/packages/core/test/unit/runtime/service.test.ts
@@ -218,7 +218,7 @@ async function createService(
 	const config: TrustedAgentsConfig = {
 		agentId: 1,
 		chain: "eip155:8453",
-		ows: { wallet: "test", apiKey: "ows_key_test" },
+		ows: { wallet: "test", passphrase: "test-passphrase" },
 		dataDir,
 		chains: {},
 		inviteExpirySeconds: 3600,

--- a/packages/openclaw-plugin/src/registry.ts
+++ b/packages/openclaw-plugin/src/registry.ts
@@ -563,7 +563,7 @@ export class OpenClawTapRegistry {
 		const signingProvider = new OwsSigningProvider(
 			config.ows.wallet,
 			config.chain,
-			config.ows.apiKey,
+			config.ows.passphrase,
 		);
 		const context = buildDefaultTapRuntimeContext(config, { signingProvider });
 		const notificationQueue = new TapNotificationQueue();

--- a/packages/openclaw-plugin/test/registry.test.ts
+++ b/packages/openclaw-plugin/test/registry.test.ts
@@ -99,7 +99,7 @@ describe("OpenClawTapRegistry", () => {
 			config: {
 				agentId: 7,
 				chain: "eip155:8453",
-				ows: { wallet: "test-wallet", apiKey: "test-key" },
+				ows: { wallet: "test-wallet", passphrase: "test-passphrase" },
 				inviteExpirySeconds: 600,
 				dataDir,
 			},

--- a/skills/trusted-agents/SKILL.md
+++ b/skills/trusted-agents/SKILL.md
@@ -106,13 +106,10 @@ tap init --chain base
 tap init --chain base --wallet my-existing-wallet
 ```
 
-**If policies exist** that already cover the selected chain: Mention them to the user. `tap init` will detect compatible policies and offer to reuse them.
-
 During `tap init`:
 1. OWS is checked (and installed if missing)
 2. A new wallet is created (or the specified one is used)
-3. A signing policy is created with chain restrictions (or a compatible one is reused)
-4. A scoped API key is issued for the agent
+3. The wallet passphrase is saved in TAP config so the local runtime can use OWS native signing
 
 Flags: `--wallet <name>` (use existing wallet), `--passphrase <passphrase>` (wallet passphrase), `--non-interactive` (skip prompts, use defaults).
 
@@ -526,10 +523,9 @@ This command:
 1. Reads the existing private key from `identity/agent.key`
 2. Preserves the XMTP database encryption key (computed from the old key and saved to config)
 3. Imports the key into an OWS wallet
-4. Creates a signing policy and scoped API key
-5. Verifies the OWS wallet address matches the original
-6. Updates `config.yaml` with the `ows` block
-7. Deletes `identity/agent.key`
+4. Verifies the OWS wallet address matches the original
+5. Updates `config.yaml` with the `ows` block
+6. Deletes `identity/agent.key`
 
 Flags: `--passphrase <passphrase>` (wallet passphrase for OWS import), `--non-interactive` (skip prompts).
 
@@ -556,5 +552,5 @@ The agent keeps its on-chain identity, contacts, and conversation history — on
 | `No matching scheduling grant` | Peer needs to publish a `scheduling/request` grant to you |
 | `OWS not installed` | Install with `curl -fsSL https://docs.openwallet.sh/install.sh \| bash` |
 | `ows.wallet is required` | Run `tap init` to set up an OWS wallet, or `tap migrate-wallet` if you have a legacy key |
-| `ows.apiKey must start with ows_key_` | The API key in config is invalid — re-run `tap init` or create a new key with `ows key create` |
+| `ows.passphrase must be a string` | Fix the configured wallet passphrase, or re-run `tap init` / `tap migrate-wallet` |
 | `Address mismatch after OWS import` | The OWS wallet derived a different address — check the wallet or try importing again |


### PR DESCRIPTION
## What this fixes
TAP's OWS signer was producing the wrong signature for x402 EIP-712 payments.

For x402 uploads we need a real EIP-712 signature over the USDC `TransferWithAuthorization` payload. TAP was not doing that. `OwsSigningProvider.signTypedData()` hashed the typed data locally and then called `owsSignMessage(..., "hex")`. OWS treats that as personal-sign, adds the Ethereum signed-message prefix, and returns a signature that does not verify as EIP-712. The facilitator then rejects the payment with `invalid_exact_evm_payload_signature`.

This PR makes TAP call OWS native `signTypedData` for typed-data payloads, which fixes the actual broken flow.

## Why the passphrase change is in this PR
The intended OWS agent model is still API-token access with policies. The skills/docs say that clearly, and they describe `ows_key_...` tokens being passed where the `passphrase` argument goes.

The problem is that the current SDK behavior does not match that expectation for typed-data signing. I verified this directly against the installed OWS SDK on March 30, 2026:
- `signMessage(..., ows_key_...)` works
- `signTypedData(..., ows_key_...)` fails with: `invalid input: EIP-712 typed data signing via API key is not yet supported; use sign_transaction`
- `signTypedData(..., <wallet passphrase>)` works

So the passphrase change is not because scoped API keys are a bad idea. It is because native typed-data signing, which x402 needs, is only available through the owner-passphrase path in the current OWS SDK.

In other words: this PR fixes TAP against the OWS behavior that exists today, not the ideal OWS behavior we would prefer.

## Scope of the change
- switch TAP's OWS integration from stored `ows.api_key` to stored `ows.passphrase`
- replace the fake hash-plus-signMessage typed-data flow with native OWS `signTypedData`
- normalize missing `EIP712Domain` fields before sending typed data into OWS, because the viem/x402 path omits them and OWS requires them
- keep Base working when OWS cannot produce raw EIP-7702 authorization signatures by falling back to EOA execution instead of failing mid-request
- remove the now-unused OWS API-key/policy helper surface from the CLI library
- update init, migration, OpenClaw wiring, docs, and regression coverage to match the new runtime model

## What this does not claim to solve
This does not make passphrase-backed agent access the ideal long-term design.

The better long-term state is:
- OWS supports policy-gated `signTypedData` for API tokens
- OWS supports raw EIP-7702 authorization signing through the same scoped model
- TAP moves back to scoped API-key auth instead of storing a wallet passphrase

Until OWS exposes those primitives, TAP cannot both use scoped API tokens and produce valid x402 typed-data signatures through the current SDK.

## Breaking change
- TAP now stores `ows.passphrase` in `config.yaml` instead of `ows.api_key`
- the env override is now `TAP_OWS_PASSPHRASE` instead of `TAP_OWS_API_KEY`
- `tap init` and `tap migrate-wallet` no longer create OWS policies or API keys

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- live Base x402 IPFS upload after the fix succeeded: `ipfs://bafkreigezwdyt4rinjpsx4ifmhqvz2gjr76rzmwmfd4ziiqi7xpzx6mtly`
- live Taiko paid IPFS upload after the fix succeeded: `ipfs://QmPG5zQxuN1GgigDpiWBwLAeYEQcCPTRtvqdHKv7CZay8P`

## Notes for reviewers
- The core functional fix is in `packages/core/src/signing/ows-provider.ts`.
- The Base execution fallback is defensive. OWS still does not expose raw EIP-7702 authorization signing, so keeping `eip7702` selected would just fail later in the request path.
- Regression tests now verify recovered signer equality for typed data instead of only checking signature shape.
