### PR TITLE
fix(signing): use hex encoding for BigInts and fix EIP-7702 authorization signing

### DIFF
--- a/packages/core/src/signing/ows-provider.ts
+++ b/packages/core/src/signing/ows-provider.ts
@@ -5,7 +5,7 @@ import {
 	signTypedData as owsSignTypedData,
 } from "@open-wallet-standard/core";
 import type { Hex, SignableMessage, TransactionSerializable } from "viem";
-import { concatHex, keccak256, numberToHex, serializeTransaction, toHex, toRlp } from "viem";
+import { concatHex, numberToHex, serializeTransaction, toHex, toRlp } from "viem";
 import type {
 	AuthorizationParameters,
 	SignTypedDataParameters,
@@ -97,9 +97,14 @@ export class OwsSigningProvider implements SigningProvider {
 			([name, type]) => ({ name, type }),
 		);
 
+		// OWS parses decimal uint with u128; hex avoids the overflow for large values like maxUint256.
 		const typedDataJson = JSON.stringify(
 			{ types: { ...types, EIP712Domain: domainFields }, primaryType, domain, message },
-			(_key, value) => (typeof value === "bigint" ? value.toString() : value),
+			(_key, value) => {
+				if (typeof value !== "bigint") return value;
+				const hex = value.toString(16);
+				return `0x${hex.length % 2 ? `0${hex}` : hex}`;
+			},
 		);
 
 		const result = owsSignTypedData(this.walletName, this.chain, typedDataJson, this.apiKey);
@@ -127,19 +132,20 @@ export class OwsSigningProvider implements SigningProvider {
 			throw new Error("nonce is required for signAuthorization");
 		}
 
-		// EIP-7702 authorization hash:
-		// keccak256(0x05 || rlp([chain_id, address, nonce]))
-		const encoded = toRlp([numberToHex(chainId), contractAddress, numberToHex(nonce)]);
-		const authHash = keccak256(concatHex(["0x05", encoded]));
-
-		// Sign the raw hash using signMessage with hex encoding
-		// Strip 0x prefix — OWS expects raw hex
-		const result = owsSignMessage(
+		// EIP-7702 authorization payload: 0x05 || rlp([chain_id, address, nonce])
+		// Use signTransaction which does keccak256(bytes) → secp256k1.sign() without
+		// any prefix — signMessage adds EIP-191 which corrupts the authorization signature.
+		// RLP integer encoding: 0 is the empty byte string ("0x"), not "0x0".
+		const rlpInt = (n: number): `0x${string}` => (n === 0 ? "0x" : numberToHex(n));
+		const authPayload = concatHex([
+			"0x05",
+			toRlp([rlpInt(chainId), contractAddress, rlpInt(nonce)]),
+		]);
+		const result = owsSignTransaction(
 			this.walletName,
 			this.chain,
-			authHash.slice(2),
+			authPayload.slice(2),
 			this.apiKey,
-			"hex",
 		);
 
 		const sig = ensureHexPrefix(result.signature);

--- a/packages/core/test/signing/ows-provider.test.ts
+++ b/packages/core/test/signing/ows-provider.test.ts
@@ -6,6 +6,8 @@ import {
 	deleteWallet,
 	revokeApiKey,
 } from "@open-wallet-standard/core";
+import { recoverAddress } from "viem";
+import { hashAuthorization } from "viem/experimental";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { OwsSigningProvider } from "../../src/signing/ows-provider.js";
 
@@ -144,6 +146,29 @@ describe("OwsSigningProvider", () => {
 		expect(auth.r).toMatch(/^0x[0-9a-fA-F]{64}$/);
 		expect(auth.s).toMatch(/^0x[0-9a-fA-F]{64}$/);
 		expect(auth.v === 27n || auth.v === 28n).toBe(true);
+	});
+
+	it("signAuthorization signature recovers to the correct address", async () => {
+		const provider = new OwsSigningProvider(WALLET_NAME, CHAIN, apiKey);
+		const address = await provider.getAddress();
+
+		const authParams = {
+			contractAddress: "0x0000000000000000000000000000000000000001" as `0x${string}`,
+			chainId: 8453,
+			nonce: 0,
+		};
+		const auth = await provider.signAuthorization(authParams);
+
+		// Compute the EIP-7702 authorization hash the same way viem does
+		const authHash = hashAuthorization(authParams);
+
+		// Recover the signer from the signature + hash
+		const recovered = await recoverAddress({
+			hash: authHash,
+			signature: { r: auth.r, s: auth.s, v: auth.v },
+		});
+
+		expect(recovered.toLowerCase()).toBe(address.toLowerCase());
 	});
 
 	it("signAuthorization throws if chainId is missing", async () => {


### PR DESCRIPTION
## Summary

- **BigInt hex encoding in signTypedData**: OWS parses decimal `uint` values using Rust's `u128`, which overflows for values larger than 2^128 (e.g. `maxUint256` used in EIP-3009 `validBefore`). Changed the JSON replacer to serialize all BigInts as even-length hex strings (`0x` prefix), which OWS handles correctly at any size.

- **EIP-7702 signAuthorization fix**: Switched from `signMessage` to `signTransaction` for signing the authorization payload. `signMessage` always prepends the EIP-191 prefix (`\x19Ethereum Signed Message:\n<length>`), which corrupts the EIP-7702 authorization signature. `signTransaction` performs `keccak256(bytes) → secp256k1.sign()` without any prefix — exactly what EIP-7702 requires. This also eliminates the need for manual `keccak256` hashing since `signTransaction` handles it internally.

- **RLP zero encoding bugfix**: Fixed integer-to-RLP encoding for zero values (nonce=0, chainId=0). `numberToHex(0)` returns `"0x0"` which RLP encodes as a single `0x00` byte, but the EIP-7702 spec requires integer 0 to be the empty byte string (`"0x"`, encoded as `0x80` in RLP).

- **Signature recovery test**: Added a verification test that signs an authorization, recomputes the hash via viem's `hashAuthorization`, recovers the signer address, and asserts it matches the provider's address.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test packages/core/test/signing/ows-provider.test.ts` — 13/13 pass (including new recovery test)
- [x] `bun test packages/core/test/signing/ows-eip712-verify.test.ts` — 3/3 pass (BigInt chainId already verified)
- [x] `bun run test` — 540 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signature material and signing method for EIP-712 BigInts and EIP-7702 authorizations; mistakes would produce invalid signatures or break downstream verification.
> 
> **Overview**
> Fixes `OwsSigningProvider` typed-data signing by serializing all `bigint` values to even-length `0x`-prefixed hex in the JSON payload, avoiding OWS decimal `u128` overflow for large `uint*` values.
> 
> Corrects EIP-7702 `signAuthorization` by signing the raw `0x05 || rlp([chainId, address, nonce])` payload via `owsSignTransaction` (avoiding `signMessage`/EIP-191 prefixing), and fixes RLP integer encoding for zero values.
> 
> Adds a test that recomputes the authorization hash (`hashAuthorization`) and uses `recoverAddress` to assert the produced signature recovers to the provider’s address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 958f6a7443f75235f7afaac9d8790d660e3588c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->