### PR TITLE
fix(runtime): harden transport and user flows

### DIFF
--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -119,6 +119,7 @@ export async function connectCommand(
 					await pollForActiveContact(
 						runtime.trustStore,
 						peerAgent.agentId,
+						peerAgent.chain,
 						Math.ceil(waitMs / 1000),
 						opts,
 						startTime,
@@ -155,6 +156,20 @@ export async function connectCommand(
 		}
 
 		const result = outcome.result;
+		if (result.status === "pending" && outcome.status === "completed" && waitMs > 0) {
+			if (
+				await pollForActiveContact(
+					runtime.trustStore,
+					peerAgent.agentId,
+					peerAgent.chain,
+					Math.ceil(waitMs / 1000),
+					opts,
+					startTime,
+				)
+			) {
+				return;
+			}
+		}
 
 		if (result.status === "active") {
 			success(
@@ -218,6 +233,7 @@ export async function connectCommand(
 async function pollForActiveContact(
 	trustStore: ITrustStore,
 	peerAgentId: number,
+	peerChain: string,
 	waitSeconds: number,
 	opts: GlobalOptions,
 	startTime: number,
@@ -225,10 +241,11 @@ async function pollForActiveContact(
 	const pollIntervalMs = 3000;
 	const deadline = Date.now() + waitSeconds * 1000;
 
-	while (Date.now() < deadline) {
-		await new Promise((r) => setTimeout(r, pollIntervalMs));
+	while (Date.now() <= deadline) {
 		const contacts = await trustStore.getContacts();
-		const match = contacts.find((c) => c.peerAgentId === peerAgentId && c.status === "active");
+		const match = contacts.find(
+			(c) => c.peerAgentId === peerAgentId && c.peerChain === peerChain && c.status === "active",
+		);
 		if (match) {
 			info(`Connection with ${match.peerDisplayName} is now active.`, opts);
 			success(
@@ -244,6 +261,10 @@ async function pollForActiveContact(
 			);
 			return true;
 		}
+		if (Date.now() >= deadline) {
+			break;
+		}
+		await new Promise((r) => setTimeout(r, pollIntervalMs));
 	}
 	return false;
 }

--- a/packages/cli/src/commands/contacts-remove.ts
+++ b/packages/cli/src/commands/contacts-remove.ts
@@ -1,3 +1,4 @@
+import { TransportOwnershipError } from "trusted-agents-core";
 import type { TapRuntime } from "trusted-agents-sdk";
 import { createCliRuntime } from "../lib/cli-runtime.js";
 import { loadConfig } from "../lib/config-loader.js";
@@ -30,6 +31,15 @@ export async function contactsRemoveCommand(
 			await runtime.service.revokeConnection(contact);
 			info(`Sent connection/revoke to ${contact.peerDisplayName} (#${contact.peerAgentId}).`, opts);
 		} catch (err) {
+			if (err instanceof TransportOwnershipError) {
+				error(
+					"TRANSPORT_ERROR",
+					`Contact removal must run through the active TAP owner so revoke can be delivered first. Use the running TAP host to remove ${contact.peerDisplayName}.`,
+					opts,
+				);
+				process.exitCode = 2;
+				return;
+			}
 			info(
 				`Could not deliver connection/revoke to ${contact.peerDisplayName} — removing locally anyway. ${err instanceof Error ? err.message : String(err)}`,
 				opts,

--- a/packages/cli/src/lib/cli-runtime.ts
+++ b/packages/cli/src/lib/cli-runtime.ts
@@ -151,6 +151,7 @@ export async function createCliRuntime(options: CliRuntimeOptions): Promise<TapR
 
 	const runtime = await createTapRuntime({
 		dataDir,
+		preloadedConfig: config,
 		configOptions: {
 			// Pass the chain and extra chain configs from the CLI so the SDK
 			// resolves the same chain map when it re-loads internally.

--- a/packages/cli/src/lib/config-loader.ts
+++ b/packages/cli/src/lib/config-loader.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
 	type ExecutionMode,
 	type ExecutionPaymasterProvider,
@@ -21,6 +21,9 @@ export function resolveDataDir(opts: GlobalOptions): string {
 	const envDir = process.env.TAP_DATA_DIR;
 	if (envDir) {
 		return envDir;
+	}
+	if (opts.config) {
+		return dirname(resolve(opts.config));
 	}
 	return join(process.env.HOME ?? homedir(), ".trustedagents");
 }

--- a/packages/cli/test/config-loader.test.ts
+++ b/packages/cli/test/config-loader.test.ts
@@ -35,16 +35,14 @@ describe("config-loader", () => {
 
 		it("allows --config without a separately selected data dir", async () => {
 			process.env.HOME = tmpDir;
-			const defaultDataDir = join(tmpDir, ".trustedagents");
 			const configPath = join(tmpDir, "custom-config.yaml");
-			await mkdir(defaultDataDir, { recursive: true });
 			await writeFile(configPath, ["agent_id: 1", "chain: eip155:8453", ""].join("\n"), "utf-8");
 
 			const config = await loadConfig({ config: configPath }, { requireAgentId: false });
 
 			expect(config.agentId).toBe(1);
 			expect(config.chain).toBe("eip155:8453");
-			expect(config.dataDir).toBe(defaultDataDir);
+			expect(config.dataDir).toBe(tmpDir);
 		});
 
 		it("should prefer config.yaml inside dataDir when it exists", async () => {
@@ -79,6 +77,11 @@ describe("config-loader", () => {
 			process.env.TAP_DATA_DIR = "/env/data";
 			const dir = resolveDataDir({ dataDir: "/flag/data" });
 			expect(dir).toBe("/flag/data");
+		});
+
+		it("uses the config file directory when --config is set without a separate data dir", () => {
+			const dir = resolveDataDir({ config: "/custom/agent/config.yaml" });
+			expect(dir).toBe("/custom/agent");
 		});
 	});
 

--- a/packages/cli/test/connect.test.ts
+++ b/packages/cli/test/connect.test.ts
@@ -224,6 +224,51 @@ describe("tap connect", () => {
 		expect(errorMock).not.toHaveBeenCalled();
 	});
 
+	it("keeps waiting after a queued command finishes with a pending result", async () => {
+		createCliRuntimeMock.mockResolvedValue({
+			...buildRuntime(async () => ({
+				connectionId: "conn-abc",
+				peerName: "Alice",
+				peerAgentId: 42,
+				status: "pending" as const,
+				receipt: { messageId: "msg-1" },
+			})),
+			trustStore: {
+				getContacts: vi.fn(async () => [
+					{
+						connectionId: "conn-abc",
+						peerAgentId: 42,
+						peerChain: "eip155:8453",
+						peerDisplayName: "Alice",
+						status: "active",
+					},
+				]),
+			},
+		});
+		runOrQueueTapCommandMock.mockResolvedValue({
+			status: "completed",
+			queued: true,
+			jobId: "job-1",
+			result: {
+				connectionId: "conn-abc",
+				peerName: "Alice",
+				peerAgentId: 42,
+				status: "pending" as const,
+				receipt: { messageId: "msg-1" },
+			},
+		});
+
+		await connectCommand(INVITE_URL, OPTS, 30, false, false);
+
+		expect(process.exitCode).toBeUndefined();
+		expect(successMock).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "active", waited: true }),
+			OPTS,
+			expect.any(Number),
+		);
+		expect(errorMock).not.toHaveBeenCalled();
+	});
+
 	it("no --yes flag: no prompt is called when service returns active", async () => {
 		const activeResult = {
 			connectionId: "conn-abc",

--- a/packages/cli/test/contacts-remove.test.ts
+++ b/packages/cli/test/contacts-remove.test.ts
@@ -1,3 +1,4 @@
+import { TransportOwnershipError } from "trusted-agents-core";
 /**
  * Tests for `tap contacts remove` — verifies that the command:
  * - Sends a connection/revoke via the service before removing locally
@@ -5,7 +6,6 @@
  * - Returns NOT_FOUND when the connectionId does not exist
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { TransportOwnershipError } from "trusted-agents-core";
 
 const { loadConfigMock, createCliRuntimeMock, successMock, errorMock, infoMock } = vi.hoisted(
 	() => ({

--- a/packages/cli/test/contacts-remove.test.ts
+++ b/packages/cli/test/contacts-remove.test.ts
@@ -5,6 +5,7 @@
  * - Returns NOT_FOUND when the connectionId does not exist
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { TransportOwnershipError } from "trusted-agents-core";
 
 const { loadConfigMock, createCliRuntimeMock, successMock, errorMock, infoMock } = vi.hoisted(
 	() => ({
@@ -84,7 +85,7 @@ describe("tap contacts remove", () => {
 		expect(stop).toHaveBeenCalledOnce();
 	});
 
-	it("still removes locally even when revokeConnection throws", async () => {
+	it("still removes locally when revokeConnection throws a non-ownership error", async () => {
 		const revokeConnection = vi.fn(async () => {
 			throw new Error("transport unavailable");
 		});
@@ -117,6 +118,35 @@ describe("tap contacts remove", () => {
 		expect(process.exitCode).not.toBe(4);
 		// Runtime was cleaned up
 		expect(stop).toHaveBeenCalledOnce();
+	});
+
+	it("does not remove locally when another TAP process owns transport", async () => {
+		const revokeConnection = vi.fn(async () => {
+			throw new TransportOwnershipError("owned");
+		});
+		const removeContact = vi.fn(async () => {});
+
+		const stop = vi.fn(async () => {});
+		createCliRuntimeMock.mockResolvedValue({
+			trustStore: {
+				getContacts: vi.fn(async () => [ACTIVE_CONTACT]),
+				removeContact,
+			},
+			service: {
+				revokeConnection,
+			},
+			stop,
+		});
+
+		await contactsRemoveCommand("conn-abc-123", OPTS);
+
+		expect(process.exitCode).toBe(2);
+		expect(removeContact).not.toHaveBeenCalled();
+		expect(errorMock).toHaveBeenCalledWith(
+			"TRANSPORT_ERROR",
+			expect.stringContaining("active TAP owner"),
+			OPTS,
+		);
 	});
 
 	it("returns NOT_FOUND when the connectionId does not exist", async () => {

--- a/packages/core/src/identity/registration-file.ts
+++ b/packages/core/src/identity/registration-file.ts
@@ -321,12 +321,7 @@ function extractMappedIpv4(host: string): string | null {
 		return null;
 	}
 
-	return [
-		(high >> 8) & 0xff,
-		high & 0xff,
-		(low >> 8) & 0xff,
-		low & 0xff,
-	].join(".");
+	return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(".");
 }
 
 function isRedirectResponse(status: number): boolean {

--- a/packages/core/src/identity/registration-file.ts
+++ b/packages/core/src/identity/registration-file.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { IdentityError, isEthereumAddress, toErrorMessage } from "../common/index.js";
 import type { RegistrationFile } from "./types.js";
 
@@ -141,7 +142,7 @@ export async function fetchRegistrationFile(uri: string): Promise<RegistrationFi
 	const timeout = setTimeout(() => controller.abort(), 10_000);
 
 	try {
-		const response = await fetch(resolvedUri, { signal: controller.signal });
+		const response = await fetchRegistrationResponse(resolvedUri, controller.signal);
 		if (!response.ok) {
 			throw new IdentityError(
 				`Failed to fetch registration file from ${resolvedUri}: HTTP ${response.status}`,
@@ -187,17 +188,43 @@ function isSafeRemoteUri(uri: string): boolean {
 	const url = parseRegistrationUrl(uri);
 	const host = normalizeHostname(url.hostname);
 
-	if (host === "localhost" || host === "::1" || host.endsWith(".local")) {
+	if (host === "localhost" || host.endsWith(".local")) {
 		return false;
 	}
-	if (/^127\./.test(host)) return false;
-	if (/^10\./.test(host)) return false;
-	if (/^169\.254\./.test(host)) return false;
-	if (/^192\.168\./.test(host)) return false;
-	if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return false;
-	if (isBlockedIpv6Host(host)) return false;
+	if (isBlockedIpHost(host)) return false;
 
 	return true;
+}
+
+async function fetchRegistrationResponse(uri: string, signal: AbortSignal): Promise<Response> {
+	let currentUri = uri;
+
+	for (let redirects = 0; redirects <= 5; redirects += 1) {
+		if (!isSafeRemoteUri(currentUri)) {
+			throw new IdentityError(`Registration URI is not allowed: ${currentUri}`);
+		}
+
+		const response = await fetch(currentUri, {
+			signal,
+			redirect: "manual",
+		});
+		if (!isRedirectResponse(response.status)) {
+			return response;
+		}
+
+		const location = response.headers.get("location");
+		if (!location) {
+			throw new IdentityError(`Registration fetch redirect missing Location header: ${currentUri}`);
+		}
+
+		const nextUrl = new URL(location, currentUri);
+		if (nextUrl.protocol !== "https:") {
+			throw new IdentityError(`Unsupported registration URI protocol: ${nextUrl.protocol}`);
+		}
+		currentUri = nextUrl.toString();
+	}
+
+	throw new IdentityError(`Registration fetch exceeded redirect limit for ${uri}`);
 }
 
 function parseRegistrationUrl(uri: string): URL {
@@ -212,9 +239,36 @@ function normalizeHostname(hostname: string): string {
 	return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
 }
 
-function isBlockedIpv6Host(host: string): boolean {
-	if (!host.includes(":")) {
+function isBlockedIpHost(host: string): boolean {
+	const mappedIpv4 = extractMappedIpv4(host);
+	if (mappedIpv4) {
+		return isBlockedIpv4Host(mappedIpv4);
+	}
+
+	const ipVersion = isIP(host);
+	if (ipVersion === 4) {
+		return isBlockedIpv4Host(host);
+	}
+	if (ipVersion !== 6) {
 		return false;
+	}
+
+	return isBlockedIpv6Host(host);
+}
+
+function isBlockedIpv4Host(host: string): boolean {
+	return (
+		/^127\./.test(host) ||
+		/^10\./.test(host) ||
+		/^169\.254\./.test(host) ||
+		/^192\.168\./.test(host) ||
+		/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
+	);
+}
+
+function isBlockedIpv6Host(host: string): boolean {
+	if (host === "::1") {
+		return true;
 	}
 
 	const firstHextet = getLeadingIpv6Hextet(host);
@@ -236,4 +290,45 @@ function getLeadingIpv6Hextet(host: string): number | null {
 
 	const parsed = Number.parseInt(firstSegment, 16);
 	return Number.isNaN(parsed) ? null : parsed;
+}
+
+function extractMappedIpv4(host: string): string | null {
+	const normalized = host.toLowerCase();
+	const prefix = "::ffff:";
+	if (!normalized.startsWith(prefix)) {
+		return null;
+	}
+	const ipv4 = normalized.slice(prefix.length);
+	if (isIP(ipv4) === 4) {
+		return ipv4;
+	}
+
+	const parts = ipv4.split(":");
+	if (parts.length !== 2) {
+		return null;
+	}
+
+	const high = Number.parseInt(parts[0] ?? "", 16);
+	const low = Number.parseInt(parts[1] ?? "", 16);
+	if (
+		Number.isNaN(high) ||
+		Number.isNaN(low) ||
+		high < 0 ||
+		high > 0xffff ||
+		low < 0 ||
+		low > 0xffff
+	) {
+		return null;
+	}
+
+	return [
+		(high >> 8) & 0xff,
+		high & 0xff,
+		(low >> 8) & 0xff,
+		low & 0xff,
+	].join(".");
+}
+
+function isRedirectResponse(status: number): boolean {
+	return status >= 300 && status < 400;
 }

--- a/packages/core/src/identity/registration-file.ts
+++ b/packages/core/src/identity/registration-file.ts
@@ -325,5 +325,5 @@ function extractMappedIpv4(host: string): string | null {
 }
 
 function isRedirectResponse(status: number): boolean {
-	return status >= 300 && status < 400;
+	return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }

--- a/packages/core/src/runtime/service.ts
+++ b/packages/core/src/runtime/service.ts
@@ -2759,7 +2759,9 @@ export class TapMessagingService {
 		await process(contact, entry.requestId, request);
 	}
 
-	private async findActiveContactForPendingEntry(entry: RequestJournalEntry): Promise<Contact | null> {
+	private async findActiveContactForPendingEntry(
+		entry: RequestJournalEntry,
+	): Promise<Contact | null> {
 		const metadata = entry.metadata as Record<string, unknown> | undefined;
 		const peerChain = typeof metadata?.peerChain === "string" ? metadata.peerChain : undefined;
 		if (peerChain) {
@@ -3308,11 +3310,7 @@ export class TapMessagingService {
 		outgoing: ProtocolMessage,
 		actionType: string,
 	): Promise<void> {
-		const delivery = buildPendingActionResultDeliveryFromRequest(
-			contact,
-			schedulingId,
-			outgoing,
-		);
+		const delivery = buildPendingActionResultDeliveryFromRequest(contact, schedulingId, outgoing);
 		await this.context.requestJournal.putOutbound({
 			requestId: String(delivery.request.id),
 			requestKey: `outbound:${delivery.request.method}:${String(delivery.request.id)}`,
@@ -3784,17 +3782,25 @@ export class TapMessagingService {
 		);
 	}
 
-	private async retryPendingResults<T extends { peerAgentId: number; peerName: string }>(
-		method: string,
-		parse: (metadata: Record<string, unknown> | undefined) => T | null,
-		deliver: (delivery: T) => Promise<void>,
-		errorLabel: (delivery: T) => string,
-	): Promise<number> {
+	private async retryPendingDeliveries<
+		T extends { peerAgentId: number; peerName: string },
+	>(options: {
+		kind: "request" | "result";
+		method: string;
+		parse: (metadata: Record<string, unknown> | undefined) => T | null;
+		deliver: (delivery: T) => Promise<void>;
+		errorLabel: (delivery: T) => string;
+		recordFailure: (
+			requestId: string,
+			metadata: Record<string, unknown> | undefined,
+			error: unknown,
+		) => Promise<void>;
+	}): Promise<number> {
 		const pending = await this.context.requestJournal.listPending("outbound");
 		let processed = 0;
 		const now = Date.now();
 		for (const entry of pending) {
-			if (entry.kind !== "result" || entry.method !== method) {
+			if (entry.kind !== options.kind || entry.method !== options.method) {
 				continue;
 			}
 
@@ -3810,26 +3816,26 @@ export class TapMessagingService {
 			if (Number.isFinite(createdMs) && now - createdMs > PENDING_RESULT_MAX_AGE_MS) {
 				this.log(
 					"warn",
-					`Abandoning pending ${method} delivery ${entry.requestId} for agent #${entry.peerAgentId}: older than ${Math.round(PENDING_RESULT_MAX_AGE_MS / 3_600_000)}h`,
+					`Abandoning pending ${options.method} delivery ${entry.requestId} for agent #${entry.peerAgentId}: older than ${Math.round(PENDING_RESULT_MAX_AGE_MS / 3_600_000)}h`,
 				);
 				await this.markJournalEntryCompleted(entry.requestId).catch(() => {});
 				continue;
 			}
 
-			const delivery = parse(entry.metadata);
+			const delivery = options.parse(entry.metadata);
 			if (!delivery) {
 				continue;
 			}
 			try {
-				await deliver(delivery);
+				await options.deliver(delivery);
 				processed += 1;
 			} catch (error: unknown) {
 				this.logResultDeliveryFailure(
-					errorLabel(delivery),
+					options.errorLabel(delivery),
 					`${delivery.peerName} (#${delivery.peerAgentId})`,
 					error,
 				);
-				await this.recordDeliveryFailure(entry.requestId, entry.metadata, error);
+				await options.recordFailure(entry.requestId, entry.metadata, error);
 			}
 		}
 		return processed;
@@ -3916,40 +3922,27 @@ export class TapMessagingService {
 		return receipt;
 	}
 
-	private async retryPendingPermissionsUpdates(): Promise<number> {
-		const pending = await this.context.requestJournal.listPending("outbound");
-		let processed = 0;
-		for (const entry of pending) {
-			if (entry.kind !== "request" || entry.method !== PERMISSIONS_UPDATE) {
-				continue;
-			}
-			const delivery = parsePendingPermissionsUpdateDelivery(entry.metadata);
-			if (!delivery) {
-				continue;
-			}
-
-			try {
-				await this.deliverPendingPermissionsUpdate(delivery);
-				processed += 1;
-			} catch (error: unknown) {
-				this.logResultDeliveryFailure(
-					"Permissions update",
-					`${delivery.peerName} (#${delivery.peerAgentId})`,
-					error,
-				);
-				await this.recordSendFailure(entry.requestId, error);
-			}
-		}
-		return processed;
+	private retryPendingPermissionsUpdates(): Promise<number> {
+		return this.retryPendingDeliveries<PendingPermissionsUpdateDelivery>({
+			kind: "request",
+			method: PERMISSIONS_UPDATE,
+			parse: parsePendingPermissionsUpdateDelivery,
+			deliver: (d) => this.deliverPendingPermissionsUpdate(d).then(() => undefined),
+			errorLabel: () => "Permissions update",
+			recordFailure: (requestId, _metadata, error) => this.recordSendFailure(requestId, error),
+		});
 	}
 
 	private retryPendingActionResults(): Promise<number> {
-		return this.retryPendingResults(
-			ACTION_RESULT,
-			parsePendingActionResultDelivery,
-			(d) => this.deliverPendingActionResult(d),
-			(d) => `Action result ${d.actionId}`,
-		);
+		return this.retryPendingDeliveries<PendingActionResultDelivery>({
+			kind: "result",
+			method: ACTION_RESULT,
+			parse: parsePendingActionResultDelivery,
+			deliver: (d) => this.deliverPendingActionResult(d),
+			errorLabel: (d) => `Action result ${d.actionId}`,
+			recordFailure: (requestId, metadata, error) =>
+				this.recordDeliveryFailure(requestId, metadata, error),
+		});
 	}
 
 	private async retryPendingConnectionRequests(): Promise<number> {

--- a/packages/core/src/runtime/service.ts
+++ b/packages/core/src/runtime/service.ts
@@ -702,7 +702,9 @@ export class TapMessagingService {
 
 	async listPendingRequests(): Promise<TapServiceStatus["pendingRequests"]> {
 		const pending = await this.context.requestJournal.listPending();
-		return pending.filter((entry) => entry.kind === "request").map(toPendingRequestView);
+		return pending
+			.filter((entry) => entry.kind === "request" && !isOutboundDeliveryEntry(entry))
+			.map(toPendingRequestView);
 	}
 
 	private async findCancellableSchedulingRequest(
@@ -1385,7 +1387,11 @@ export class TapMessagingService {
 			try {
 				receipt = await this.deliverPendingPermissionsUpdate(delivery);
 			} catch (error: unknown) {
-				await this.recordSendFailure(String(request.id), error);
+				await this.recordDeliveryFailure(
+					String(request.id),
+					serializePendingPermissionsUpdateDelivery(delivery),
+					error,
+				);
 				throw error;
 			}
 
@@ -1873,10 +1879,10 @@ export class TapMessagingService {
 		// Avoids reading request-journal.json twice per sync.
 		const allPending = await this.context.requestJournal.listPending();
 		const pendingRequests = allPending
-			.filter((entry) => entry.kind === "request")
+			.filter((entry) => entry.kind === "request" && !isOutboundDeliveryEntry(entry))
 			.map(toPendingRequestView);
 		const pendingDeliveries = allPending
-			.filter((entry) => entry.direction === "outbound" && entry.kind === "result")
+			.filter((entry) => entry.direction === "outbound" && isDeliveryEntry(entry))
 			.map((entry) => toPendingDeliveryView(entry, Date.now()));
 		return {
 			synced: true,
@@ -3929,7 +3935,8 @@ export class TapMessagingService {
 			parse: parsePendingPermissionsUpdateDelivery,
 			deliver: (d) => this.deliverPendingPermissionsUpdate(d).then(() => undefined),
 			errorLabel: () => "Permissions update",
-			recordFailure: (requestId, _metadata, error) => this.recordSendFailure(requestId, error),
+			recordFailure: (requestId, metadata, error) =>
+				this.recordDeliveryFailure(requestId, metadata, error),
 		});
 	}
 
@@ -5157,6 +5164,15 @@ function parseRecordedTransferResponse(
 	}
 
 	return parsed as TransferActionResponse;
+}
+
+function isDeliveryEntry(entry: RequestJournalEntry): boolean {
+	if (entry.kind === "result") return true;
+	return entry.kind === "request" && entry.method === PERMISSIONS_UPDATE;
+}
+
+function isOutboundDeliveryEntry(entry: RequestJournalEntry): boolean {
+	return entry.direction === "outbound" && isDeliveryEntry(entry);
 }
 
 function toPendingRequestView(entry: RequestJournalEntry): TapPendingRequest {

--- a/packages/core/src/runtime/service.ts
+++ b/packages/core/src/runtime/service.ts
@@ -194,6 +194,16 @@ interface PendingActionResultDelivery extends Record<string, unknown> {
 	request: ProtocolMessage;
 }
 
+interface PendingPermissionsUpdateDelivery extends Record<string, unknown> {
+	type: "permissions-update-delivery";
+	connectionId: string;
+	peerAgentId: number;
+	peerName: string;
+	peerAddress: `0x${string}`;
+	grantSet: PermissionGrantSet;
+	request: ProtocolMessage;
+}
+
 // ──────────────────────────────────────────────────────────────
 // Connect waiter infrastructure (spec §3.2)
 // ──────────────────────────────────────────────────────────────
@@ -470,6 +480,7 @@ export class TapMessagingService {
 	private outboxPoller: ReturnType<typeof setInterval> | null = null;
 	private outboxPollInFlight = false;
 	private transportSessionReentryDepth = 0;
+	private legacyStateMigrationsComplete = false;
 	private manifestLoaded = false;
 
 	constructor(context: TapRuntimeContext, options: TapServiceOptions = {}) {
@@ -586,7 +597,7 @@ export class TapMessagingService {
 		// lock across the migration makes it mutually exclusive by construction.
 		await this.ownerLock.acquire();
 		try {
-			await this.runLegacyStateMigrations();
+			await this.ensureLegacyStateMigrated();
 			this.context.transport.setHandlers(this.handlers);
 			await this.context.transport.start?.();
 			this.running = true;
@@ -902,10 +913,7 @@ export class TapMessagingService {
 						);
 					}
 
-					const contact = findUniqueContactForAgentId(
-						await this.context.trustStore.getContacts(),
-						latestEntry.peerAgentId,
-					);
+					const contact = await this.findActiveContactForPendingEntry(latestEntry);
 					if (!contact) {
 						throw new ValidationError(
 							`No active contact found for pending scheduling request ${requestId}`,
@@ -926,11 +934,13 @@ export class TapMessagingService {
 						"rejected",
 					);
 
-					await this.context.transport.send(contact.peerAgentId, outgoing, {
-						peerAddress: contact.peerAgentAddress,
-						waitForAck: false,
-					});
-					await this.appendConversationLogSafe(contact, outgoing, "outgoing");
+					await this.persistSchedulingActionResult(
+						contact,
+						latestEntry.requestId,
+						latestProposal.schedulingId,
+						outgoing,
+						"cancel",
+					);
 					const clearedLocalEvent = await this.cancelLocalSchedulingEvent(
 						latestEntry.requestId,
 						latestTracking.localEventId,
@@ -1350,10 +1360,7 @@ export class TapMessagingService {
 	): Promise<TapPublishGrantSetResult> {
 		return await this.withTransportSession(async () => {
 			const contact = await this.requireContact(peer);
-			const updatedPermissions = replaceGrantedByMe(contact.permissions, grantSet);
-			await this.context.trustStore.updateContact(contact.connectionId, {
-				permissions: updatedPermissions,
-			});
+			await this.completeSupersededPermissionsUpdates(contact.connectionId);
 
 			const request = buildPermissionsUpdate({
 				grantSet,
@@ -1362,9 +1369,25 @@ export class TapMessagingService {
 				note,
 				timestamp: nowISO(),
 			});
-			const receipt = await this.context.transport.send(contact.peerAgentId, request, {
-				peerAddress: contact.peerAgentAddress,
+			const delivery = buildPendingPermissionsUpdateDelivery(contact, grantSet, request);
+			await this.context.requestJournal.putOutbound({
+				requestId: String(request.id),
+				requestKey: `outbound:${request.method}:${String(request.id)}`,
+				direction: "outbound",
+				kind: "request",
+				method: request.method,
+				peerAgentId: contact.peerAgentId,
+				status: "pending",
+				metadata: serializePendingPermissionsUpdateDelivery(delivery),
 			});
+
+			let receipt: TransportReceipt;
+			try {
+				receipt = await this.deliverPendingPermissionsUpdate(delivery);
+			} catch (error: unknown) {
+				await this.recordSendFailure(String(request.id), error);
+				throw error;
+			}
 
 			await this.appendLedger({
 				peer: peerLabel(contact),
@@ -1608,6 +1631,7 @@ export class TapMessagingService {
 	private async processOutboxInternal(): Promise<number> {
 		let processed = await this.retryPendingConnectionRequests();
 		processed += await this.retryPendingConnectionResults();
+		processed += await this.retryPendingPermissionsUpdates();
 		processed += await this.retryPendingActionResults();
 		processed += await this.drainQueuedJournalCommands();
 		return processed;
@@ -1819,6 +1843,7 @@ export class TapMessagingService {
 		await this.ownerLock.acquire();
 		this.transportSessionReentryDepth += 1;
 		try {
+			await this.ensureLegacyStateMigrated();
 			this.context.transport.setHandlers(this.handlers);
 			await this.context.transport.start?.();
 			try {
@@ -1896,6 +1921,14 @@ export class TapMessagingService {
 		await this.migratePendingConnects();
 		await this.migrateOutbox();
 		await this.context.requestJournal.migrateLegacyAcked?.();
+	}
+
+	private async ensureLegacyStateMigrated(): Promise<void> {
+		if (this.legacyStateMigrationsComplete) {
+			return;
+		}
+		await this.runLegacyStateMigrations();
+		this.legacyStateMigrationsComplete = true;
 	}
 
 	private async migratePendingConnects(): Promise<void> {
@@ -2718,15 +2751,26 @@ export class TapMessagingService {
 			);
 		}
 
-		const contact = findUniqueContactForAgentId(
-			await this.context.trustStore.getContacts(),
-			entry.peerAgentId,
-		);
+		const contact = await this.findActiveContactForPendingEntry(entry);
 		if (!contact) {
 			throw new ValidationError(`No active contact found for pending ${label} ${entry.requestId}`);
 		}
 
 		await process(contact, entry.requestId, request);
+	}
+
+	private async findActiveContactForPendingEntry(entry: RequestJournalEntry): Promise<Contact | null> {
+		const metadata = entry.metadata as Record<string, unknown> | undefined;
+		const peerChain = typeof metadata?.peerChain === "string" ? metadata.peerChain : undefined;
+		if (peerChain) {
+			const contact = await this.context.trustStore.findByAgentId(entry.peerAgentId, peerChain);
+			return contact?.status === "active" ? contact : null;
+		}
+
+		return (
+			findUniqueContactForAgentId(await this.context.trustStore.getContacts(), entry.peerAgentId) ??
+			null
+		);
 	}
 
 	private async resolvePendingTransferRequest(entry: RequestJournalEntry): Promise<void> {
@@ -3022,9 +3066,11 @@ export class TapMessagingService {
 		proposal: SchedulingProposal,
 	): Promise<void> {
 		if (!this.schedulingHandler) {
-			this.log(
-				"warn",
-				`No scheduling handler configured — scheduling request ${requestId} stays pending`,
+			await this.deliverSchedulingReject(
+				contact,
+				requestId,
+				proposal,
+				"Scheduling is not supported by this TAP host",
 			);
 			return;
 		}
@@ -3113,7 +3159,13 @@ export class TapMessagingService {
 						"completed",
 					);
 
-					await this.deliverSchedulingOutgoing(contact, outgoing, "accept", proposal.schedulingId);
+					await this.persistSchedulingActionResult(
+						contact,
+						requestId,
+						proposal.schedulingId,
+						outgoing,
+						"accept",
+					);
 
 					await this.context.requestJournal.updateStatus(requestId, "completed");
 					await this.appendLedger({
@@ -3169,7 +3221,15 @@ export class TapMessagingService {
 					"scheduling/request",
 				);
 
-				await this.deliverSchedulingOutgoing(contact, outgoing, "counter", proposal.schedulingId);
+				const delivered = await this.sendSchedulingCounterRequest(
+					contact,
+					requestId,
+					outgoing,
+					proposal.schedulingId,
+				);
+				if (!delivered) {
+					break;
+				}
 
 				await this.context.requestJournal.updateStatus(requestId, "completed");
 				await this.appendLedger({
@@ -3221,7 +3281,13 @@ export class TapMessagingService {
 			"rejected",
 		);
 
-		await this.deliverSchedulingOutgoing(contact, outgoing, "reject", proposal.schedulingId);
+		await this.persistSchedulingActionResult(
+			contact,
+			requestId,
+			proposal.schedulingId,
+			outgoing,
+			"reject",
+		);
 
 		await this.context.requestJournal.updateStatus(requestId, "completed");
 		await this.appendLedger({
@@ -3235,23 +3301,58 @@ export class TapMessagingService {
 		});
 	}
 
-	private async deliverSchedulingOutgoing(
+	private async persistSchedulingActionResult(
 		contact: Contact,
+		requestId: string,
+		schedulingId: string,
 		outgoing: ProtocolMessage,
 		actionType: string,
-		schedulingId: string,
 	): Promise<void> {
+		const delivery = buildPendingActionResultDeliveryFromRequest(
+			contact,
+			schedulingId,
+			outgoing,
+		);
+		await this.context.requestJournal.putOutbound({
+			requestId: String(delivery.request.id),
+			requestKey: `outbound:${delivery.request.method}:${String(delivery.request.id)}`,
+			direction: "outbound",
+			kind: "result",
+			method: delivery.request.method,
+			peerAgentId: contact.peerAgentId,
+			correlationId: requestId,
+			status: "pending",
+			metadata: serializePendingActionResultDelivery(delivery),
+		});
+
+		try {
+			await this.deliverPendingActionResult(delivery);
+		} catch (error: unknown) {
+			this.logResultDeliveryFailure(`Scheduling ${actionType}`, peerLabel(contact), error);
+			await this.recordSendFailure(String(delivery.request.id), error);
+		}
+	}
+
+	private async sendSchedulingCounterRequest(
+		contact: Contact,
+		requestId: string,
+		outgoing: ProtocolMessage,
+		schedulingId: string,
+	): Promise<boolean> {
 		try {
 			await this.context.transport.send(contact.peerAgentId, outgoing, {
 				peerAddress: contact.peerAgentAddress,
 				waitForAck: false,
 			});
 			await this.appendConversationLogSafe(contact, outgoing, "outgoing");
+			return true;
 		} catch (error: unknown) {
+			await this.recordSendFailure(requestId, error);
 			this.log(
 				"warn",
-				`Failed to deliver scheduling ${actionType} for ${schedulingId}: ${toErrorMessage(error)}`,
+				`Failed to deliver scheduling counter for ${schedulingId}: ${toErrorMessage(error)}`,
 			);
+			return false;
 		}
 	}
 
@@ -3782,6 +3883,64 @@ export class TapMessagingService {
 			...(existing.metadata ?? {}),
 			lastError: { message, at: nowISO(), attempts },
 		});
+	}
+
+	private async completeSupersededPermissionsUpdates(connectionId: string): Promise<void> {
+		const pending = await this.context.requestJournal.listPending("outbound");
+		for (const entry of pending) {
+			if (entry.method !== PERMISSIONS_UPDATE || entry.kind !== "request") {
+				continue;
+			}
+			const delivery = parsePendingPermissionsUpdateDelivery(entry.metadata);
+			if (delivery?.connectionId !== connectionId) {
+				continue;
+			}
+			await this.markJournalEntryCompleted(entry.requestId);
+		}
+	}
+
+	private async deliverPendingPermissionsUpdate(
+		delivery: PendingPermissionsUpdateDelivery,
+	): Promise<TransportReceipt> {
+		const receipt = await this.context.transport.send(delivery.peerAgentId, delivery.request, {
+			peerAddress: delivery.peerAddress,
+			waitForAck: false,
+		});
+		const contact = await this.context.trustStore.getContact(delivery.connectionId);
+		if (contact) {
+			await this.context.trustStore.updateContact(delivery.connectionId, {
+				permissions: replaceGrantedByMe(contact.permissions, delivery.grantSet),
+			});
+		}
+		await this.markJournalEntryCompleted(String(delivery.request.id));
+		return receipt;
+	}
+
+	private async retryPendingPermissionsUpdates(): Promise<number> {
+		const pending = await this.context.requestJournal.listPending("outbound");
+		let processed = 0;
+		for (const entry of pending) {
+			if (entry.kind !== "request" || entry.method !== PERMISSIONS_UPDATE) {
+				continue;
+			}
+			const delivery = parsePendingPermissionsUpdateDelivery(entry.metadata);
+			if (!delivery) {
+				continue;
+			}
+
+			try {
+				await this.deliverPendingPermissionsUpdate(delivery);
+				processed += 1;
+			} catch (error: unknown) {
+				this.logResultDeliveryFailure(
+					"Permissions update",
+					`${delivery.peerName} (#${delivery.peerAgentId})`,
+					error,
+				);
+				await this.recordSendFailure(entry.requestId, error);
+			}
+		}
+		return processed;
 	}
 
 	private retryPendingActionResults(): Promise<number> {
@@ -4626,6 +4785,22 @@ function getLocalTimezone(): string {
 	return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
+function buildPendingActionResultDeliveryFromRequest(
+	contact: Contact,
+	actionId: string,
+	request: ProtocolMessage,
+): PendingActionResultDelivery {
+	return {
+		type: "action-result-delivery",
+		actionId,
+		connectionId: contact.connectionId,
+		peerAgentId: contact.peerAgentId,
+		peerName: contact.peerDisplayName,
+		peerAddress: contact.peerAgentAddress,
+		request,
+	};
+}
+
 function buildPendingActionResultDelivery(
 	contact: Contact,
 	requestId: string,
@@ -4639,19 +4814,33 @@ function buildPendingActionResultDelivery(
 		"transfer/request",
 		response.status,
 	);
-	return {
-		type: "action-result-delivery",
-		actionId: response.actionId,
-		connectionId: contact.connectionId,
-		peerAgentId: contact.peerAgentId,
-		peerName: contact.peerDisplayName,
-		peerAddress: contact.peerAgentAddress,
-		request,
-	};
+	return buildPendingActionResultDeliveryFromRequest(contact, response.actionId, request);
 }
 
 function serializePendingActionResultDelivery(
 	delivery: PendingActionResultDelivery,
+): Record<string, unknown> {
+	return delivery as unknown as Record<string, unknown>;
+}
+
+function buildPendingPermissionsUpdateDelivery(
+	contact: Contact,
+	grantSet: PermissionGrantSet,
+	request: ProtocolMessage,
+): PendingPermissionsUpdateDelivery {
+	return {
+		type: "permissions-update-delivery",
+		connectionId: contact.connectionId,
+		peerAgentId: contact.peerAgentId,
+		peerName: contact.peerDisplayName,
+		peerAddress: contact.peerAgentAddress,
+		grantSet,
+		request,
+	};
+}
+
+function serializePendingPermissionsUpdateDelivery(
+	delivery: PendingPermissionsUpdateDelivery,
 ): Record<string, unknown> {
 	return delivery as unknown as Record<string, unknown>;
 }
@@ -4849,6 +5038,38 @@ function parsePendingActionResultDelivery(
 		peerAgentId: metadata.peerAgentId,
 		peerName: metadata.peerName,
 		peerAddress: peerAddress as `0x${string}`,
+		request: metadata.request,
+	};
+}
+
+function parsePendingPermissionsUpdateDelivery(
+	metadata: Record<string, unknown> | undefined,
+): PendingPermissionsUpdateDelivery | null {
+	if (!metadata || metadata.type !== "permissions-update-delivery") {
+		return null;
+	}
+
+	const peerAddress = asString(metadata.peerAddress);
+	const grantSet = metadata.grantSet;
+	if (
+		typeof metadata.connectionId !== "string" ||
+		typeof metadata.peerAgentId !== "number" ||
+		typeof metadata.peerName !== "string" ||
+		!peerAddress?.startsWith("0x") ||
+		!grantSet ||
+		typeof grantSet !== "object" ||
+		!isProtocolMessage(metadata.request)
+	) {
+		return null;
+	}
+
+	return {
+		type: "permissions-update-delivery",
+		connectionId: metadata.connectionId,
+		peerAgentId: metadata.peerAgentId,
+		peerName: metadata.peerName,
+		peerAddress: peerAddress as `0x${string}`,
+		grantSet: grantSet as PermissionGrantSet,
 		request: metadata.request,
 	};
 }

--- a/packages/core/src/runtime/transport-owner-lock.ts
+++ b/packages/core/src/runtime/transport-owner-lock.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { open, readFile, realpath, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { fsErrorCode, resolveDataDir } from "../common/index.js";
@@ -6,6 +7,7 @@ export interface TransportOwnerInfo {
 	pid: number;
 	owner: string;
 	acquiredAt: string;
+	instanceId?: string;
 	dataDirRealpath?: string;
 }
 
@@ -22,6 +24,7 @@ export class TransportOwnershipError extends Error {
 export class TransportOwnerLock {
 	private readonly lockPath: string;
 	private readonly dataDirRealpathPromise: Promise<string>;
+	private readonly instanceId = randomUUID();
 	private held = false;
 
 	constructor(
@@ -47,6 +50,7 @@ export class TransportOwnerLock {
 						pid: process.pid,
 						owner: this.owner,
 						acquiredAt: new Date().toISOString(),
+						instanceId: this.instanceId,
 						dataDirRealpath,
 					};
 					await handle.writeFile(JSON.stringify(payload, null, "\t"), "utf-8");
@@ -62,12 +66,6 @@ export class TransportOwnerLock {
 
 				const currentOwner = await this.readOwner();
 				if (currentOwner?.dataDirRealpath && currentOwner.dataDirRealpath !== dataDirRealpath) {
-					await rm(this.lockPath, { force: true });
-					continue;
-				}
-				// Same logical owner re-acquiring means the previous instance crashed
-				// without releasing the lock. Always treat as stale.
-				if (currentOwner && currentOwner.owner === this.owner) {
 					await rm(this.lockPath, { force: true });
 					continue;
 				}
@@ -97,6 +95,10 @@ export class TransportOwnerLock {
 			return;
 		}
 		this.held = false;
+		const currentOwner = await this.readOwner();
+		if (currentOwner?.instanceId !== this.instanceId) {
+			return;
+		}
 		await rm(this.lockPath, { force: true });
 	}
 
@@ -117,6 +119,7 @@ export class TransportOwnerLock {
 					pid: parsed.pid,
 					owner: parsed.owner,
 					acquiredAt: parsed.acquiredAt,
+					instanceId: typeof parsed.instanceId === "string" ? parsed.instanceId : undefined,
 					dataDirRealpath:
 						typeof parsed.dataDirRealpath === "string" ? parsed.dataDirRealpath : undefined,
 				};

--- a/packages/core/src/scheduling/grants.ts
+++ b/packages/core/src/scheduling/grants.ts
@@ -15,13 +15,8 @@ function getLocalDayOfWeek(date: Date, timezone: string): number {
 	return index === -1 ? date.getDay() : index;
 }
 
-function isSlotWithinTimeRange(
-	isoStart: string,
-	rangeStart: string,
-	rangeEnd: string,
-	timezone: string,
-): boolean {
-	const date = new Date(isoStart);
+function toLocalMinutes(isoTime: string, timezone: string): number {
+	const date = new Date(isoTime);
 	const formatter = new Intl.DateTimeFormat("en-US", {
 		hour: "numeric",
 		minute: "numeric",
@@ -29,19 +24,32 @@ function isSlotWithinTimeRange(
 		timeZone: timezone,
 	});
 	const localTime = formatter.format(date);
-	// localTime format: "HH:MM" (24h), e.g. "14:30"
-	// Normalize to "HH:MM" in case hour is single digit
 	const [hourStr, minuteStr] = localTime.split(":");
 	const hour = Number(hourStr);
 	const minute = Number(minuteStr);
-	const totalMinutes = hour * 60 + minute;
+	return hour * 60 + minute;
+}
+
+function isSlotWithinTimeRange(
+	isoStart: string,
+	isoEnd: string,
+	rangeStart: string,
+	rangeEnd: string,
+	timezone: string,
+): boolean {
+	const slotStartMinutes = toLocalMinutes(isoStart, timezone);
+	const slotEndMinutes = toLocalMinutes(isoEnd, timezone);
 
 	const rsParts = rangeStart.split(":").map(Number);
 	const reParts = rangeEnd.split(":").map(Number);
 	const rangeStartMinutes = (rsParts[0] ?? 0) * 60 + (rsParts[1] ?? 0);
 	const rangeEndMinutes = (reParts[0] ?? 0) * 60 + (reParts[1] ?? 0);
 
-	return totalMinutes >= rangeStartMinutes && totalMinutes < rangeEndMinutes;
+	return (
+		slotStartMinutes >= rangeStartMinutes &&
+		slotEndMinutes <= rangeEndMinutes &&
+		slotStartMinutes < slotEndMinutes
+	);
 }
 
 // ── Exports ───────────────────────────────────────────────────────────────────
@@ -85,7 +93,7 @@ export function filterSchedulingProposalSlots(
 			if (
 				typeof range.start === "string" &&
 				typeof range.end === "string" &&
-				!isSlotWithinTimeRange(slot.start, range.start, range.end, timezone)
+				!isSlotWithinTimeRange(slot.start, slot.end, range.start, range.end, timezone)
 			) {
 				return false;
 			}

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -755,6 +755,10 @@ export class XmtpTransport implements TransportProvider {
 		senderAddresses: `0x${string}`[],
 		message: ProtocolMessage,
 	): Promise<Contact | null> {
+		if (this.isBootstrapMethod(message.method)) {
+			return null;
+		}
+
 		const metadataContact = await this.findContactByConnectionId(senderAddresses, message);
 		if (metadataContact) {
 			return metadataContact;

--- a/packages/core/test/scheduling/grants.test.ts
+++ b/packages/core/test/scheduling/grants.test.ts
@@ -126,6 +126,19 @@ describe("matchesSchedulingConstraints", () => {
 		expect(matchesSchedulingConstraints(grant, proposal)).toBe(false);
 	});
 
+	it("returns false when a slot starts inside the window but ends after it", () => {
+		const grant = makeGrant({
+			constraints: {
+				allowedTimeRange: { start: "09:00", end: "18:00" },
+				timezone: "UTC",
+			},
+		});
+		const proposal = makeProposal({
+			slots: [{ start: "2026-03-27T17:30:00Z", end: "2026-03-27T18:30:00Z" }],
+		});
+		expect(matchesSchedulingConstraints(grant, proposal)).toBe(false);
+	});
+
 	it("returns false when allowedTimeRange.start is missing", () => {
 		// Incomplete range object should not match (missing start)
 		const grant = makeGrant({

--- a/packages/core/test/unit/identity/registration-file.test.ts
+++ b/packages/core/test/unit/identity/registration-file.test.ts
@@ -152,6 +152,7 @@ describe("fetchRegistrationFile", () => {
 	it.each([
 		"https://169.254.10.20/registration.json",
 		"https://[::1]/registration.json",
+		"https://[::ffff:127.0.0.1]/registration.json",
 		"https://[fe80::1]/registration.json",
 		"https://[fc00::1]/registration.json",
 		"https://[fd12:3456::1]/registration.json",
@@ -162,5 +163,21 @@ describe("fetchRegistrationFile", () => {
 		await expect(result).rejects.toBeInstanceOf(IdentityError);
 		await expect(result).rejects.toThrow("Registration URI is not allowed");
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects redirects to unsafe hosts", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: {
+					location: "https://127.0.0.1/registration.json",
+				},
+			}),
+		);
+
+		await expect(
+			fetchRegistrationFile("https://safe.example.test/registration.json"),
+		).rejects.toThrow("Registration URI is not allowed");
+		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/core/test/unit/runtime/migration.test.ts
+++ b/packages/core/test/unit/runtime/migration.test.ts
@@ -169,6 +169,22 @@ describe("legacy state migration — pending-connects.json", () => {
 		expect(existsSync(join(dir, "pending-connects.json"))).toBe(false);
 	});
 
+	it("runs migrations during syncOnce for short-lived sessions", async () => {
+		const dir = makeTempDir();
+		writeFileSync(
+			join(dir, "pending-connects.json"),
+			JSON.stringify({ pendingConnects: [SAMPLE_LEGACY_ENTRY] }),
+		);
+
+		const { service, trustStore } = makeServiceHarness(dir);
+		await service.syncOnce();
+
+		const contact = await trustStore.findByAgentId(42, "eip155:8453");
+		expect(contact).not.toBeNull();
+		expect(contact?.status).toBe("connecting");
+		expect(existsSync(join(dir, "pending-connects.json"))).toBe(false);
+	});
+
 	it("is idempotent — running start twice produces one contact, not two", async () => {
 		const dir = makeTempDir();
 		writeFileSync(

--- a/packages/core/test/unit/runtime/service.connect.test.ts
+++ b/packages/core/test/unit/runtime/service.connect.test.ts
@@ -233,7 +233,10 @@ describe("connect() synchronous waiting (spec §3.1 + Task 4.2)", () => {
 		const connectPromise = service.connect({ inviteUrl: url, waitMs: 5_000 });
 
 		// Deliver the accepted result asynchronously after send() completes.
-		await sleep(30);
+		for (let attempt = 0; attempt < 20 && transport.sentMessages.length === 0; attempt += 1) {
+			await sleep(10);
+		}
+		expect(transport.sentMessages[0]).toBeDefined();
 		const sentRequestId = String(transport.sentMessages[0]!.message.id);
 		await transport.handlers.onResult?.({
 			from: PEER_AGENT.agentId,

--- a/packages/core/test/unit/runtime/service.test.ts
+++ b/packages/core/test/unit/runtime/service.test.ts
@@ -2551,7 +2551,11 @@ describe("TapMessagingService", () => {
 			): Promise<TransportReceipt> {
 				this.sentMessages.push({ peerId, message, ...(options ? { options } : {}) });
 				const response = parseSchedulingActionResponse(message);
-				if (message.method === "action/result" && response?.type === "scheduling/cancel" && this.failOnce) {
+				if (
+					message.method === "action/result" &&
+					response?.type === "scheduling/cancel" &&
+					this.failOnce
+				) {
 					this.failOnce = false;
 					throw new TransportError("temporary cancel send failure");
 				}

--- a/packages/core/test/unit/runtime/service.test.ts
+++ b/packages/core/test/unit/runtime/service.test.ts
@@ -26,7 +26,10 @@ import {
 import type { FileRequestJournal } from "../../../src/runtime/request-journal.js";
 import { FileRequestJournal as FileRequestJournalImpl } from "../../../src/runtime/request-journal.js";
 import { TapMessagingService } from "../../../src/runtime/service.js";
-import { parseSchedulingActionResponse } from "../../../src/scheduling/index.js";
+import {
+	parseSchedulingActionRequest,
+	parseSchedulingActionResponse,
+} from "../../../src/scheduling/index.js";
 import type {
 	ProtocolMessage,
 	TransportHandlers,
@@ -1023,6 +1026,67 @@ describe("TapMessagingService", () => {
 		expect((entry?.metadata as Record<string, unknown>)?.commandResult).toEqual(
 			expect.objectContaining({ status: "completed" }),
 		);
+	});
+
+	it("only updates local grants after permissions/update is durably delivered", async () => {
+		const activeContact = makeActiveContact("conn-grants-durable");
+		const trustStore = createMemoryTrustStore([activeContact]);
+		const grantSet = createGrantSet([{ grantId: "durable-chat", scope: "general-chat" }]);
+
+		class FlakyPermissionsTransport extends FakeTransport {
+			private failOnce = true;
+
+			override async send(
+				peerId: number,
+				message: ProtocolMessage,
+				options?: TransportSendOptions,
+			): Promise<TransportReceipt> {
+				this.sentMessages.push({ peerId, message, ...(options ? { options } : {}) });
+				if (message.method === "permissions/update" && this.failOnce) {
+					this.failOnce = false;
+					throw new TransportError("temporary permissions update send failure");
+				}
+				return {
+					received: true,
+					requestId: String(message.id),
+					status: options?.waitForAck === false ? "published" : "received",
+					receivedAt: "2026-03-07T00:00:00.000Z",
+				};
+			}
+		}
+
+		const transport = new FlakyPermissionsTransport();
+		const { service, requestJournal } = await createService(
+			{},
+			{
+				transport,
+				trustStore,
+			},
+		);
+
+		await service.start();
+
+		await expect(
+			service.publishGrantSet(activeContact.peerDisplayName, grantSet, "durable publish"),
+		).rejects.toThrow("temporary permissions update send failure");
+
+		const afterFailure = await trustStore.getContact(activeContact.connectionId);
+		expect(afterFailure?.permissions.grantedByMe.grants).toEqual([]);
+
+		const pendingEntry = (await requestJournal.listPending("outbound")).find(
+			(entry) => entry.method === "permissions/update",
+		);
+		expect(pendingEntry).toBeDefined();
+
+		const report = await service.syncOnce();
+		expect(report.pendingDeliveries).toEqual([]);
+
+		const afterRetry = await trustStore.getContact(activeContact.connectionId);
+		expect(afterRetry?.permissions.grantedByMe.grants).toEqual(
+			expect.arrayContaining([expect.objectContaining({ grantId: "durable-chat" })]),
+		);
+
+		await service.stop();
 	});
 
 	it("captures an action result that arrives before requestFunds finishes sending", async () => {
@@ -2202,6 +2266,131 @@ describe("TapMessagingService", () => {
 		await service.stop();
 	});
 
+	it("rejects scheduling requests when no scheduling handler is configured", async () => {
+		const contact = makeActiveContact("conn-scheduling-unsupported");
+		const transport = new FakeTransport();
+		const { service, requestJournal } = await createService(
+			{},
+			{
+				transport,
+				trustStore: createMemoryTrustStore([contact]),
+			},
+		);
+
+		await service.start();
+
+		const proposal = {
+			type: "scheduling/propose",
+			schedulingId: "sch-unsupported-1",
+			title: "Unsupported Meeting",
+			duration: 30,
+			slots: [{ start: "2026-03-08T16:00:00.000Z", end: "2026-03-08T16:30:00.000Z" }],
+			originTimezone: "UTC",
+		};
+		const request = buildOutgoingActionRequest(
+			contact,
+			"Scheduling proposal",
+			proposal,
+			"scheduling/request",
+		);
+
+		await expect(
+			transport.handlers.onRequest?.({
+				from: contact.peerAgentId,
+				senderInboxId: "peer-inbox-scheduling-unsupported",
+				message: request,
+			}),
+		).resolves.toEqual({ status: "queued" });
+
+		await sleep(50);
+
+		expect(await requestJournal.getByRequestId(String(request.id))).toEqual(
+			expect.objectContaining({
+				status: "completed",
+			}),
+		);
+
+		const actionResults = transport.sentMessages.filter(
+			(entry) => entry.message.method === "action/result",
+		);
+		expect(actionResults).toHaveLength(1);
+		expect(parseSchedulingActionResponse(actionResults[0]!.message)).toEqual(
+			expect.objectContaining({
+				type: "scheduling/reject",
+				schedulingId: "sch-unsupported-1",
+				reason: "Scheduling is not supported by this TAP host",
+			}),
+		);
+
+		await service.stop();
+	});
+
+	it("resolves pending scheduling requests using peerChain when agent ids collide", async () => {
+		const contact = makeActiveContact("conn-scheduling-mainnet");
+		const sameAgentOtherChain: Contact = {
+			...makeActiveContact("conn-scheduling-taiko"),
+			peerChain: "eip155:167000",
+			peerDisplayName: "Bob on Taiko",
+		};
+		const transport = new FakeTransport();
+		const schedulingHandler = {
+			evaluateProposal: vi.fn(async () => ({ action: "defer" as const })),
+			handleAccept: vi.fn(async () => ({ eventId: "evt-mainnet-only" })),
+			handleCancel: vi.fn(async () => {}),
+		} as unknown as NonNullable<
+			ConstructorParameters<typeof TapMessagingService>[1]["schedulingHandler"]
+		>;
+		const { service } = await createService(
+			{},
+			{
+				transport,
+				trustStore: createMemoryTrustStore([contact, sameAgentOtherChain]),
+				serviceOptions: { schedulingHandler },
+			},
+		);
+
+		await service.start();
+
+		const proposal = {
+			type: "scheduling/propose",
+			schedulingId: "sch-mainnet-only",
+			title: "Mainnet Meeting",
+			duration: 30,
+			slots: [{ start: "2026-03-08T16:00:00.000Z", end: "2026-03-08T16:30:00.000Z" }],
+			originTimezone: "UTC",
+		};
+		const request = buildOutgoingActionRequest(
+			contact,
+			"Scheduling proposal",
+			proposal,
+			"scheduling/request",
+		);
+
+		await expect(
+			transport.handlers.onRequest?.({
+				from: contact.peerAgentId,
+				senderInboxId: "peer-inbox-scheduling-mainnet",
+				message: request,
+			}),
+		).resolves.toEqual({ status: "queued" });
+
+		await sleep(50);
+
+		await expect(service.resolvePending(String(request.id), false)).resolves.toEqual(
+			expect.objectContaining({
+				pendingRequests: [],
+			}),
+		);
+
+		const actionResults = transport.sentMessages.filter(
+			(entry) => entry.message.method === "action/result",
+		);
+		expect(actionResults).toHaveLength(1);
+		expect(actionResults[0]?.peerId).toBe(contact.peerAgentId);
+
+		await service.stop();
+	});
+
 	it("settles scheduling requests when confirmMeeting returns false", async () => {
 		const contact: Contact = {
 			...makeActiveContact("conn-confirm-false-scheduling"),
@@ -2272,7 +2461,13 @@ describe("TapMessagingService", () => {
 			}),
 		).resolves.toEqual({ status: "queued" });
 
-		await sleep(50);
+		for (let attempt = 0; attempt < 20; attempt += 1) {
+			const entry = await requestJournal.getByRequestId(String(request.id));
+			if (entry?.status === "completed") {
+				break;
+			}
+			await sleep(10);
+		}
 		expect(confirmMeeting).toHaveBeenCalledOnce();
 		expect(schedulingHandler.handleAccept).not.toHaveBeenCalled();
 		expect(await requestJournal.getByRequestId(String(request.id))).toEqual(
@@ -2343,6 +2538,77 @@ describe("TapMessagingService", () => {
 		await service.stop();
 	});
 
+	it("retries scheduling cancellation delivery after the initial send fails", async () => {
+		const contact = makeActiveContact("conn-cancel-retry");
+
+		class FlakySchedulingCancelTransport extends FakeTransport {
+			private failOnce = true;
+
+			override async send(
+				peerId: number,
+				message: ProtocolMessage,
+				options?: TransportSendOptions,
+			): Promise<TransportReceipt> {
+				this.sentMessages.push({ peerId, message, ...(options ? { options } : {}) });
+				const response = parseSchedulingActionResponse(message);
+				if (message.method === "action/result" && response?.type === "scheduling/cancel" && this.failOnce) {
+					this.failOnce = false;
+					throw new TransportError("temporary cancel send failure");
+				}
+				return {
+					received: true,
+					requestId: String(message.id),
+					status: options?.waitForAck === false ? "published" : "received",
+					receivedAt: "2026-03-07T00:00:00.000Z",
+				};
+			}
+		}
+
+		const transport = new FlakySchedulingCancelTransport();
+		const { service, requestJournal } = await createService(
+			{},
+			{
+				transport,
+				trustStore: createMemoryTrustStore([contact]),
+			},
+		);
+
+		await service.start();
+		const proposal = {
+			type: "scheduling/propose" as const,
+			schedulingId: "sch-cancel-retry-1",
+			title: "Retry Candidate",
+			duration: 45,
+			slots: [{ start: "2026-03-08T20:00:00.000Z", end: "2026-03-08T20:45:00.000Z" }],
+			originTimezone: "UTC",
+		};
+		const requestResult = await service.requestMeeting({
+			peer: contact.peerDisplayName,
+			proposal,
+		});
+
+		const report = await service.cancelPendingSchedulingRequest(
+			String(requestResult.receipt.requestId),
+			"Need to reschedule",
+		);
+		expect(report.pendingRequests).toEqual([]);
+		expect(report.pendingDeliveries).toEqual([
+			expect.objectContaining({
+				method: "action/result",
+			}),
+		]);
+		expect(await requestJournal.getByRequestId(String(requestResult.receipt.requestId))).toEqual(
+			expect.objectContaining({
+				status: "completed",
+			}),
+		);
+
+		const retryReport = await service.syncOnce();
+		expect(retryReport.pendingDeliveries).toEqual([]);
+
+		await service.stop();
+	});
+
 	it("completes the superseded outbound request when a counter-proposal arrives", async () => {
 		const contact = makeActiveContact("conn-counter-cleanup");
 		const transport = new FakeTransport();
@@ -2401,6 +2667,84 @@ describe("TapMessagingService", () => {
 				direction: "inbound",
 			}),
 		]);
+
+		await service.stop();
+	});
+
+	it("keeps inbound scheduling requests pending when a counter-proposal cannot be delivered", async () => {
+		const contact = makeActiveContact("conn-counter-failure");
+
+		class FlakySchedulingCounterTransport extends FakeTransport {
+			override async send(
+				peerId: number,
+				message: ProtocolMessage,
+				options?: TransportSendOptions,
+			): Promise<TransportReceipt> {
+				this.sentMessages.push({ peerId, message, ...(options ? { options } : {}) });
+				const request = parseSchedulingActionRequest(message);
+				if (message.method === "action/request" && request?.type === "scheduling/counter") {
+					throw new TransportError("temporary counter send failure");
+				}
+				return {
+					received: true,
+					requestId: String(message.id),
+					status: options?.waitForAck === false ? "published" : "received",
+					receivedAt: "2026-03-07T00:00:00.000Z",
+				};
+			}
+		}
+
+		const transport = new FlakySchedulingCounterTransport();
+		const schedulingHandler = {
+			evaluateProposal: vi.fn(async () => ({
+				action: "counter" as const,
+				slots: [{ start: "2026-03-09T20:00:00.000Z", end: "2026-03-09T20:45:00.000Z" }],
+			})),
+			handleAccept: vi.fn(async () => ({ eventId: "evt-counter-failure" })),
+			handleCancel: vi.fn(async () => {}),
+		} as unknown as NonNullable<
+			ConstructorParameters<typeof TapMessagingService>[1]["schedulingHandler"]
+		>;
+		const { service, requestJournal } = await createService(
+			{},
+			{
+				transport,
+				trustStore: createMemoryTrustStore([contact]),
+				serviceOptions: { schedulingHandler },
+			},
+		);
+
+		await service.start();
+		const proposal = {
+			type: "scheduling/propose" as const,
+			schedulingId: "sch-counter-failure-1",
+			title: "Counter Failure Candidate",
+			duration: 45,
+			slots: [{ start: "2026-03-08T20:00:00.000Z", end: "2026-03-08T20:45:00.000Z" }],
+			originTimezone: "UTC",
+		};
+		const request = buildOutgoingActionRequest(
+			contact,
+			"Counter proposal",
+			proposal,
+			"scheduling/request",
+		);
+
+		await expect(
+			transport.handlers.onRequest?.({
+				from: contact.peerAgentId,
+				senderInboxId: "peer-inbox-counter-failure",
+				message: request,
+			}),
+		).resolves.toEqual({ status: "queued" });
+
+		await sleep(50);
+
+		expect(await requestJournal.getByRequestId(String(request.id))).toEqual(
+			expect.objectContaining({
+				status: "pending",
+			}),
+		);
 
 		await service.stop();
 	});

--- a/packages/core/test/unit/runtime/transport-owner-lock.test.ts
+++ b/packages/core/test/unit/runtime/transport-owner-lock.test.ts
@@ -32,8 +32,12 @@ describe("TransportOwnerLock", () => {
 		);
 
 		const lockPath = join(dataDir, ".transport.lock");
-		const raw = JSON.parse(await readFile(lockPath, "utf-8")) as { owner: string };
+		const raw = JSON.parse(await readFile(lockPath, "utf-8")) as {
+			owner: string;
+			instanceId?: string;
+		};
 		expect(raw.owner).toBe("tap:test-owner");
+		expect(typeof raw.instanceId).toBe("string");
 
 		await lock.release();
 		expect(await lock.inspect()).toBeNull();
@@ -84,38 +88,20 @@ describe("TransportOwnerLock", () => {
 		);
 	});
 
-	it("reclaims stale lock from same logical owner (restart scenario)", async () => {
+	it("rejects a second live owner even when the owner label matches", async () => {
 		const dataDir = await createDataDir();
-		const lockPath = join(dataDir, ".transport.lock");
-		const realDataDir = await import("node:fs/promises").then((m) => m.realpath(dataDir));
+		const first = new TransportOwnerLock(dataDir, "openclaw:myagent");
+		const second = new TransportOwnerLock(dataDir, "openclaw:myagent");
 
-		// Simulate a stale lock left by a crashed process with the same owner label
-		// but a live PID (simulates PID recycling by using current PID)
-		await writeFile(
-			lockPath,
-			JSON.stringify(
-				{
-					pid: process.pid,
-					owner: "openclaw:myagent",
-					acquiredAt: "2026-01-01T00:00:00.000Z",
-					dataDirRealpath: realDataDir,
-				},
-				null,
-				"\t",
-			),
-			"utf-8",
-		);
+		await first.acquire();
 
-		// Same owner label should reclaim even though PID appears alive
-		const lock = new TransportOwnerLock(dataDir, "openclaw:myagent");
-		await lock.acquire();
-
-		expect(await lock.inspect()).toEqual(
-			expect.objectContaining({
+		await expect(second.acquire()).rejects.toMatchObject<Partial<TransportOwnershipError>>({
+			name: "TransportOwnershipError",
+			currentOwner: expect.objectContaining({
 				pid: process.pid,
 				owner: "openclaw:myagent",
 			}),
-		);
+		});
 	});
 
 	it("reclaims copied lock files that point at a different data dir", async () => {
@@ -137,6 +123,35 @@ describe("TransportOwnerLock", () => {
 			expect.objectContaining({
 				pid: process.pid,
 				owner: "tap:copied",
+			}),
+		);
+	});
+
+	it("does not delete a newer owner's lock during release", async () => {
+		const dataDir = await createDataDir();
+		const first = new TransportOwnerLock(dataDir, "tap:first");
+
+		await first.acquire();
+		await writeFile(
+			join(dataDir, ".transport.lock"),
+			JSON.stringify(
+				{
+					pid: 0,
+					owner: "tap:second",
+					acquiredAt: "2026-01-01T00:00:00.000Z",
+					instanceId: "replacement-instance",
+				},
+				null,
+				"\t",
+			),
+			"utf-8",
+		);
+
+		await first.release();
+
+		expect(await first.inspect()).toEqual(
+			expect.objectContaining({
+				owner: "tap:second",
 			}),
 		);
 	});

--- a/packages/core/test/unit/transport/xmtp.test.ts
+++ b/packages/core/test/unit/transport/xmtp.test.ts
@@ -791,6 +791,58 @@ describe("XmtpTransport", () => {
 			});
 		});
 
+		it("should ignore injected connectionId metadata on bootstrap connection/request", async () => {
+			const bootstrapTrustStore = createAmbiguousTrustStore({
+				getContact: vi.fn(async () => BOB_CONTACT),
+			});
+			const resolver = createBobResolver();
+			const transportWithResolver = new XmtpTransport(
+				{
+					...TEST_CONFIG,
+					agentResolver: resolver,
+				},
+				bootstrapTrustStore,
+			);
+			injectMockClient(transportWithResolver);
+
+			mockSetup.setInboxIdentifiers("spoofed-bootstrap-metadata-inbox", [
+				{ identifier: ALICE.address, identifierKind: 0 },
+			]);
+
+			const callback = vi.fn(
+				async (_envelope: InboundRequestEnvelope): Promise<TransportAck> => ({
+					status: "queued",
+				}),
+			);
+			transportWithResolver.setHandlers({ onRequest: callback });
+
+			const request: ProtocolMessage = {
+				jsonrpc: "2.0",
+				method: "connection/request",
+				id: "conn-bootstrap-metadata-spoof",
+				params: {
+					from: { agentId: 99, chain: "eip155:1" },
+					to: { agentId: 1, chain: "eip155:1" },
+					message: {
+						metadata: {
+							trustedAgent: {
+								connectionId: BOB_CONTACT.connectionId,
+							},
+						},
+					},
+					timestamp: new Date().toISOString(),
+				},
+			};
+
+			await internals(transportWithResolver).processMessage({
+				senderInboxId: "spoofed-bootstrap-metadata-inbox",
+				content: JSON.stringify(request),
+			});
+
+			expect(callback).not.toHaveBeenCalled();
+			expect(mockSetup.mockConversation.sendText).toHaveBeenCalled();
+		});
+
 		it("should route message/send by connection id when address lookup is ambiguous", async () => {
 			const ambiguousTrustStore = createAmbiguousTrustStore({
 				getContact: vi.fn(
@@ -996,6 +1048,62 @@ describe("XmtpTransport", () => {
 				senderInboxId: "legacy-inbox",
 				message: result,
 			});
+		});
+
+		it("should ignore injected connectionId metadata on bootstrap connection/result", async () => {
+			const bootstrapTrustStore = createAmbiguousTrustStore({
+				getContact: vi.fn(async () => BOB_CONTACT),
+			});
+			const resolver = createBobResolver({
+				agentId: BOB_CONTACT.peerAgentId,
+				capabilities: ["connection/result"],
+			});
+			const transportWithResolver = new XmtpTransport(
+				{
+					...TEST_CONFIG,
+					agentResolver: resolver,
+				},
+				bootstrapTrustStore,
+			);
+			injectMockClient(transportWithResolver);
+
+			mockSetup.setInboxIdentifiers("spoofed-bootstrap-result-inbox", [
+				{ identifier: ALICE.address, identifierKind: 0 },
+			]);
+
+			const callback = vi.fn(
+				async (_envelope: InboundRequestEnvelope): Promise<TransportAck> => ({
+					status: "received",
+				}),
+			);
+			transportWithResolver.setHandlers({ onResult: callback });
+
+			const result: ProtocolMessage = {
+				jsonrpc: "2.0",
+				method: "connection/result",
+				id: "conn-result-metadata-spoof",
+				params: {
+					requestId: "conn-request-legacy",
+					from: { agentId: BOB_CONTACT.peerAgentId, chain: BOB_CONTACT.peerChain },
+					status: "accepted",
+					message: {
+						metadata: {
+							trustedAgent: {
+								connectionId: BOB_CONTACT.connectionId,
+							},
+						},
+					},
+					timestamp: new Date().toISOString(),
+				},
+			};
+
+			await internals(transportWithResolver).processMessage({
+				senderInboxId: "spoofed-bootstrap-result-inbox",
+				content: JSON.stringify(result),
+			});
+
+			expect(callback).not.toHaveBeenCalled();
+			expect(mockSetup.mockConversation.sendText).toHaveBeenCalled();
 		});
 
 		it("should reject messages from known contacts that are not active", async () => {

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"trusted-agents-core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+			"trusted-agents-sdk": fileURLToPath(new URL("../sdk/src/index.ts", import.meta.url)),
 		},
 	},
 	test: {

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -41,6 +41,9 @@ export interface CreateTapRuntimeOptions {
 	/** Path to the agent data directory. Defaults to ~/.trustedagents */
 	dataDir?: string;
 
+	/** Preloaded config to use instead of re-reading from disk. */
+	preloadedConfig?: TrustedAgentsConfig;
+
 	/** Override options for config loading */
 	configOptions?: LoadTrustedAgentConfigOptions;
 
@@ -110,10 +113,9 @@ export class TapRuntime extends EventEmitter {
 		const dataDir = this.options.dataDir ?? DEFAULT_DATA_DIR;
 
 		// Load config
-		this.config = await loadTrustedAgentConfigFromDataDir(
-			dataDir,
-			this.options.configOptions ?? {},
-		);
+		this.config =
+			this.options.preloadedConfig ??
+			(await loadTrustedAgentConfigFromDataDir(dataDir, this.options.configOptions ?? {}));
 
 		// Create signing provider
 		let signingProvider: SigningProviderLike;

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -90,7 +90,7 @@ export interface SigningProviderLike {
  */
 export class TapRuntime extends EventEmitter {
 	private readonly options: CreateTapRuntimeOptions;
-	private config: TrustedAgentsConfig | undefined;
+	private _config: TrustedAgentsConfig | undefined;
 	private context: TapRuntimeContext | undefined;
 	private _service: TapMessagingService | undefined;
 	private initialized = false;
@@ -112,31 +112,27 @@ export class TapRuntime extends EventEmitter {
 
 		const dataDir = this.options.dataDir ?? DEFAULT_DATA_DIR;
 
-		// Load config
-		this.config =
+		this._config =
 			this.options.preloadedConfig ??
 			(await loadTrustedAgentConfigFromDataDir(dataDir, this.options.configOptions ?? {}));
 
-		// Create signing provider
 		let signingProvider: SigningProviderLike;
 		if (this.options.createSigningProvider) {
-			signingProvider = await this.options.createSigningProvider(this.config);
+			signingProvider = await this.options.createSigningProvider(this._config);
 		} else {
-			// Default: use OwsSigningProvider
 			signingProvider = new OwsSigningProvider(
-				this.config.ows.wallet,
-				this.config.chain,
-				this.config.ows.apiKey,
+				this._config.ows.wallet,
+				this._config.chain,
+				this._config.ows.apiKey,
 			);
 		}
 
-		// Build runtime context
 		const contextOptions: BuildTapRuntimeContextOptions = {
 			// biome-ignore lint/suspicious/noExplicitAny: SigningProviderLike is compatible with SigningProvider
 			signingProvider: signingProvider as any,
 			...this.options.contextOptions,
 		};
-		this.context = await buildDefaultTapRuntimeContext(this.config, contextOptions);
+		this.context = await buildDefaultTapRuntimeContext(this._config, contextOptions);
 
 		// Wire up event emission through hooks
 		const userHooks = this.options.hooks ?? {};
@@ -190,6 +186,14 @@ export class TapRuntime extends EventEmitter {
 	/** Access the request journal. Requires start() first. */
 	get requestJournal(): IRequestJournal {
 		return this.requireContext().requestJournal;
+	}
+
+	/** Access the loaded TAP config. Requires init() first. */
+	get config(): TrustedAgentsConfig {
+		if (!this._config) {
+			throw new Error("Runtime not initialized. Call start() first.");
+		}
+		return this._config;
 	}
 
 	private requireService(): TapMessagingService {

--- a/packages/sdk/test/runtime.test.ts
+++ b/packages/sdk/test/runtime.test.ts
@@ -104,7 +104,7 @@ describe("TapRuntime init", () => {
 
 		await runtime.init();
 
-		expect(runtime.service["context"].config.agentId).toBe(123);
-		expect(runtime.service["context"].config.dataDir).toBe(dataDir);
+		expect(runtime.config.agentId).toBe(123);
+		expect(runtime.config.dataDir).toBe(dataDir);
 	});
 });

--- a/packages/sdk/test/runtime.test.ts
+++ b/packages/sdk/test/runtime.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { TapRuntime, createTapRuntime } from "../src/index.js";
 
@@ -59,5 +62,49 @@ describe("TapRuntime event subscription", () => {
 		runtime.on("log", (entry) => logs.push(entry));
 		runtime.emit("log", { level: "info", message: "test" });
 		expect(logs).toEqual([{ level: "info", message: "test" }]);
+	});
+});
+
+describe("TapRuntime init", () => {
+	it("uses preloaded config instead of reloading from disk", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "tap-sdk-runtime-"));
+		const runtime = await createTapRuntime({
+			dataDir,
+			preloadedConfig: {
+				agentId: 123,
+				chain: "eip155:8453",
+				ows: { wallet: "wallet-1", apiKey: "ows_key_test" },
+				dataDir,
+				chains: {},
+				inviteExpirySeconds: 3600,
+				resolveCacheTtlMs: 60_000,
+				resolveCacheMaxEntries: 128,
+			},
+			createSigningProvider: async () =>
+				({
+					getAddress: async () => "0x0000000000000000000000000000000000000001",
+					signMessage: async () => "0x1",
+					signTypedData: async () => "0x1",
+					signTransaction: async () => "0x1",
+					signAuthorization: async () => ({}),
+				}) as never,
+			contextOptions: {
+				transport: {
+					setHandlers: () => {},
+					send: async () => ({
+						received: true,
+						requestId: "test",
+						status: "received",
+						receivedAt: new Date().toISOString(),
+					}),
+					isReachable: async () => true,
+				},
+			},
+		});
+
+		await runtime.init();
+
+		expect(runtime.service["context"].config.agentId).toBe(123);
+		expect(runtime.service["context"].config.dataDir).toBe(dataDir);
 	});
 });


### PR DESCRIPTION
Several TAP user flows could break because config resolution, transport ownership, and outbound state durability were not aligned. This makes CLI and SDK config selection consistent, hardens the transport lock and bootstrap sender checks, persists permissions and scheduling deliveries through the existing journal retry path, and turns silent scheduling stalls into explicit rejections instead of hanging forever.

It also fixes queued connect and contact removal edge cases, runs legacy migrations in short-lived sync sessions, hardens registration URI validation, and adds regression coverage across CLI, core, transport, identity, SDK, and mocked E2E paths. Verified with `bun run typecheck` and `bun run test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core runtime delivery/journaling and transport ownership locking behavior, plus tightens remote registration file fetching (redirect/IP filtering) which impacts security and connectivity edge cases.
> 
> **Overview**
> Improves TAP reliability under concurrent processes by **hardening transport ownership**: lock files now include an `instanceId`, same-label owners no longer auto-reclaim, and release won’t delete a lock it doesn’t own.
> 
> Makes outbound state more durable by **journaling and retrying `permissions/update` deliveries** and by persisting scheduling action results (accept/reject/cancel) into the request journal for retry; scheduling requests are explicitly rejected when no scheduling handler is configured, and pending-entry contact resolution now prefers `peerChain` to avoid agent-id collisions.
> 
> Tightens network/identity safety by validating registration-file fetches across redirects and blocking additional local/loopback IP forms (including IPv4-mapped IPv6), and hardens XMTP bootstrap handling to ignore spoofed `connectionId` metadata.
> 
> CLI/SDK alignment and UX fixes: CLI `--config` now implies `dataDir` from the config’s directory and passes `preloadedConfig` into the SDK runtime; `tap connect` polls for activation when queued/completed-but-pending and matches by `peerChain`; `tap contacts remove` fails fast with a clear error when another process owns transport (instead of deleting locally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d37630827f19cb6ec4227fc729fe7e6e2bdc381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->