### PR TITLE
Bug fixes: XMTP reconcile safety, cross-chain signing, non-TTY meeting approval, immediate app result delivery

### DIFF
--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -157,15 +157,18 @@ export async function connectCommand(
 
 		const result = outcome.result;
 		if (result.status === "pending" && outcome.status === "completed" && waitMs > 0) {
+			const elapsedMs = Date.now() - startTime;
+			const remainingSeconds = Math.ceil(Math.max(0, waitMs - elapsedMs) / 1000);
 			if (
-				await pollForActiveContact(
+				remainingSeconds > 0 &&
+				(await pollForActiveContact(
 					runtime.trustStore,
 					peerAgent.agentId,
 					peerAgent.chain,
-					Math.ceil(waitMs / 1000),
+					remainingSeconds,
 					opts,
 					startTime,
-				)
+				))
 			) {
 				return;
 			}

--- a/packages/cli/src/lib/cli-runtime.ts
+++ b/packages/cli/src/lib/cli-runtime.ts
@@ -125,7 +125,7 @@ export async function createCliRuntime(options: CliRuntimeOptions): Promise<TapR
 			printProposedMeeting(meeting, opts);
 
 			if (!process.stdin.isTTY) {
-				return true;
+				return false;
 			}
 
 			return await promptYesNo("Confirm this meeting? [y/N] ");

--- a/packages/cli/src/lib/cli-runtime.ts
+++ b/packages/cli/src/lib/cli-runtime.ts
@@ -134,7 +134,7 @@ export async function createCliRuntime(options: CliRuntimeOptions): Promise<TapR
 			(await override?.executeTransferAction?.(serviceConfig, request)) ??
 			(await executeOnchainTransfer(
 				serviceConfig,
-				createConfiguredSigningProvider(serviceConfig),
+				createConfiguredSigningProvider(serviceConfig, request.chain),
 				request,
 			)),
 		log: (_level, message) => {

--- a/packages/core/src/runtime/service.ts
+++ b/packages/core/src/runtime/service.ts
@@ -1890,6 +1890,13 @@ export class TapMessagingService {
 			synced: true,
 			processed: 0,
 		};
+		if (reconciled.errors && reconciled.errors > 0) {
+			const samples = reconciled.errorSamples?.join("; ") ?? "";
+			this.log(
+				"warn",
+				`Reconcile completed with ${reconciled.errors} error(s); processed ${reconciled.processed} message(s)${samples ? `. Samples: ${samples}` : ""}`,
+			);
+		}
 		await this.drain();
 		this.lastSyncAt = nowISO();
 		return reconciled.processed;

--- a/packages/core/src/runtime/service.ts
+++ b/packages/core/src/runtime/service.ts
@@ -4490,6 +4490,8 @@ export class TapMessagingService {
 
 		// Persist an outbound journal entry so reconciliation can retry delivery
 		// if the transport send fails (follows the same pattern as transfer results).
+		const actionId = typeof resultData.actionId === "string" ? resultData.actionId : requestId;
+		const delivery = buildPendingActionResultDeliveryFromRequest(contact, actionId, outgoing);
 		try {
 			await this.context.requestJournal.putOutbound({
 				requestId: String(outgoing.id),
@@ -4500,15 +4502,7 @@ export class TapMessagingService {
 				peerAgentId: contact.peerAgentId,
 				correlationId: requestId,
 				status: "pending",
-				metadata: {
-					type: "action-result-delivery",
-					actionId: typeof resultData.actionId === "string" ? resultData.actionId : requestId,
-					connectionId: contact.connectionId,
-					peerAgentId: contact.peerAgentId,
-					peerName: contact.peerDisplayName,
-					peerAddress: contact.peerAgentAddress,
-					request: outgoing,
-				} as unknown as Record<string, unknown>,
+				metadata: serializePendingActionResultDelivery(delivery),
 			});
 		} catch (journalError: unknown) {
 			this.log(
@@ -4528,6 +4522,12 @@ export class TapMessagingService {
 					`Failed to deliver app result for "${actionType}": ${toErrorMessage(deliveryError)}`,
 				);
 			}
+			return;
+		}
+		try {
+			await this.deliverPendingActionResult(delivery);
+		} catch (error: unknown) {
+			this.logActionResultDeliveryFailure(contact, actionId, error);
 		}
 	}
 

--- a/packages/core/src/transport/interface.ts
+++ b/packages/core/src/transport/interface.ts
@@ -38,6 +38,8 @@ export interface TransportReconcileOptions {
 export interface TransportReconcileResult {
 	synced: true;
 	processed: number;
+	errors?: number;
+	errorSamples?: string[];
 }
 
 export interface TransportProvider {

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -38,6 +38,16 @@ const RECONNECT_DELAY_MS = 5_000;
 const CLIENT_CREATE_TIMEOUT_MS = 30_000;
 const INBOUND_REQUEST_DEDUPE_TTL_MS = 10 * 60 * 1_000;
 const MAX_TRACKED_INBOUND_REQUESTS = 4_096;
+const MAX_RECONCILE_ERROR_SAMPLES = 5;
+
+function collectErrorSamples(samples: string[], messages: string[], conversationId: string): void {
+	for (const message of messages) {
+		if (samples.length >= MAX_RECONCILE_ERROR_SAMPLES) {
+			return;
+		}
+		samples.push(`[${conversationId}] ${message}`);
+	}
+}
 
 interface PendingRequest {
 	resolve: (receipt: TransportReceipt) => void;
@@ -257,17 +267,28 @@ export class XmtpTransport implements TransportProvider {
 		}
 
 		let processed = 0;
+		const errorSamples: string[] = [];
+		let errors = 0;
 		for (const dm of dms) {
 			try {
-				processed += await this.reconcileConversation(dm);
-			} catch {
-				// Skip this DM so one persistently-failing message doesn't block all others.
+				const result = await this.reconcileConversation(dm);
+				processed += result.processed;
+				if (result.errors.length > 0) {
+					errors += result.errors.length;
+					collectErrorSamples(errorSamples, result.errors, dm.id);
+				}
+			} catch (error) {
+				// Skip this DM so one persistently-failing DM doesn't block all others.
+				// Common causes: transient checkpoint-read errors or XMTP SDK query failures.
+				errors += 1;
+				collectErrorSamples(errorSamples, [toErrorMessage(error)], dm.id);
 			}
 		}
 
 		return {
 			synced: true,
 			processed,
+			...(errors > 0 ? { errors, errorSamples } : {}),
 		};
 	}
 
@@ -415,15 +436,16 @@ export class XmtpTransport implements TransportProvider {
 		return checkpoints;
 	}
 
-	private async reconcileConversation(dm: Dm): Promise<number> {
+	private async reconcileConversation(dm: Dm): Promise<{ processed: number; errors: string[] }> {
 		if (!this.syncState) {
-			return 0;
+			return { processed: 0, errors: [] };
 		}
 
 		const checkpoint = await this.syncState.getCheckpoint(dm.id);
 		const messages = await dm.messages(buildMessageQuery(checkpoint));
 
 		let processed = 0;
+		const errors: string[] = [];
 		for (const message of messages) {
 			if (isMessageAlreadyCheckpointed(checkpoint, message)) {
 				continue;
@@ -434,12 +456,14 @@ export class XmtpTransport implements TransportProvider {
 				if (didProcess) {
 					processed += 1;
 				}
-			} catch {
-				// Leave the checkpoint unchanged so transient failures can be retried.
+			} catch (error) {
+				// Leave the checkpoint unchanged so transient failures can be retried on the
+				// next reconcile pass. Capture the reason so the outer loop can surface it.
+				errors.push(toErrorMessage(error));
 			}
 		}
 
-		return processed;
+		return { processed, errors };
 	}
 
 	private async processMessage(message: IncomingTransportMessage): Promise<boolean> {

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -457,9 +457,12 @@ export class XmtpTransport implements TransportProvider {
 					processed += 1;
 				}
 			} catch (error) {
-				// Leave the checkpoint unchanged so transient failures can be retried on the
-				// next reconcile pass. Capture the reason so the outer loop can surface it.
+				// Stop replaying this DM on the first failure. If we kept going, a later
+				// successful message would advance the checkpoint past the failed one,
+				// leaving it below `sentAfterNs` on the next reconcile pass and permanently
+				// dropping it. Returning here preserves ordering and retry semantics.
 				errors.push(toErrorMessage(error));
+				return { processed, errors };
 			}
 		}
 

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -258,7 +258,11 @@ export class XmtpTransport implements TransportProvider {
 
 		let processed = 0;
 		for (const dm of dms) {
-			processed += await this.reconcileConversation(dm);
+			try {
+				processed += await this.reconcileConversation(dm);
+			} catch {
+				// Skip this DM so one persistently-failing message doesn't block all others.
+			}
 		}
 
 		return {

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -428,10 +428,14 @@ export class XmtpTransport implements TransportProvider {
 			if (isMessageAlreadyCheckpointed(checkpoint, message)) {
 				continue;
 			}
-			const didProcess = await this.processMessage(this.toIncomingMessage(message));
-			await this.advanceCheckpoint(dm.id, message.sentAtNs, message.id);
-			if (didProcess) {
-				processed += 1;
+			try {
+				const didProcess = await this.processMessage(this.toIncomingMessage(message));
+				await this.advanceCheckpoint(dm.id, message.sentAtNs, message.id);
+				if (didProcess) {
+					processed += 1;
+				}
+			} catch {
+				// Leave the checkpoint unchanged so transient failures can be retried.
 			}
 		}
 

--- a/packages/openclaw-plugin/src/registry.ts
+++ b/packages/openclaw-plugin/src/registry.ts
@@ -423,25 +423,18 @@ export class OpenClawTapRegistry {
 		reason?: string;
 	}) {
 		const runtime = await this.ensureRuntimeForAction(params.identity);
-		const matching = await this.findPendingSchedulingEntry(
-			runtime,
-			params.schedulingId,
-			"outbound",
-			`No scheduling request found with schedulingId: ${params.schedulingId}. It may have already been completed or cancelled.`,
-		);
 
-		const report = await runtime.mutex.runExclusive(
-			async () =>
-				await runtime.runtime.cancelPendingSchedulingRequest(matching.requestId, params.reason),
+		const result = await runtime.mutex.runExclusive(
+			async () => await runtime.runtime.cancelMeeting(params.schedulingId, params.reason),
 		);
 
 		return {
 			identity: runtime.definition.name,
 			cancelled: true,
 			schedulingId: params.schedulingId,
-			requestId: matching.requestId,
+			requestId: result.requestId,
 			...(params.reason ? { reason: params.reason } : {}),
-			pendingRequests: report.pendingRequests.length,
+			pendingRequests: result.report.pendingRequests.length,
 		};
 	}
 
@@ -617,8 +610,13 @@ export class OpenClawTapRegistry {
 				},
 			}),
 			hooks: {
-				executeTransfer: async (serviceConfig, request) =>
-					await executeOnchainTransfer(serviceConfig, signingProvider, request),
+				executeTransfer: async (serviceConfig, request) => {
+					const transferProvider =
+						request.chain === config.chain
+							? signingProvider
+							: new OwsSigningProvider(config.ows.wallet, request.chain, config.ows.apiKey);
+					return await executeOnchainTransfer(serviceConfig, transferProvider, request);
+				},
 				log: (level, message) => {
 					this.logger[level](`[trusted-agents-tap:${definition.name}] ${message}`);
 				},

--- a/packages/openclaw-plugin/src/registry.ts
+++ b/packages/openclaw-plugin/src/registry.ts
@@ -323,9 +323,13 @@ export class OpenClawTapRegistry {
 	}> {
 		const runtime = await this.ensureRuntimeForAction(params.identity);
 		const chain = params.chain ?? runtime.config.chain;
+		const transferProvider =
+			chain === runtime.config.chain
+				? runtime.signingProvider
+				: new OwsSigningProvider(runtime.config.ows.wallet, chain, runtime.config.ows.apiKey);
 		const result = await runtime.mutex.runExclusive(
 			async () =>
-				await executeOnchainTransfer(runtime.config, runtime.signingProvider, {
+				await executeOnchainTransfer(runtime.config, transferProvider, {
 					type: "transfer/request",
 					actionId: `gateway-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
 					asset: params.asset,
@@ -529,7 +533,9 @@ export class OpenClawTapRegistry {
 
 	private async ensureRuntimeStarted(name: string): Promise<ManagedTapRuntime> {
 		const runtime = await this.ensureRuntime(name);
-		await this.startRuntime(runtime);
+		if (!runtime.interval) {
+			await this.startRuntime(runtime);
+		}
 		return runtime;
 	}
 

--- a/packages/openclaw-plugin/test/registry.test.ts
+++ b/packages/openclaw-plugin/test/registry.test.ts
@@ -362,12 +362,17 @@ describe("OpenClawTapRegistry", () => {
 		});
 	});
 
-	it("cancelMeeting cancels outbound scheduling requests and forwards reason", async () => {
+	it("cancelMeeting delegates to service cancelMeeting and forwards reason", async () => {
 		const logger = createLogger();
 		const registry = new OpenClawTapRegistry({ identities: [] }, logger);
-		const cancelPendingSchedulingRequest = vi.fn(async () => ({ pendingRequests: [] }));
+		const cancelMeeting = vi.fn(async () => ({
+			requestId: "outbound-entry",
+			peerAgentId: 10,
+			schedulingId: "sch-cancel-1",
+			report: { pendingRequests: [] },
+		}));
 		vi.spyOn(registry as never, "ensureRuntimeForAction").mockResolvedValue(
-			makeSchedulingRuntime("sch-cancel-1", { cancelPendingSchedulingRequest }) as never,
+			makeSchedulingRuntime("sch-cancel-1", { cancelMeeting }) as never,
 		);
 
 		const result = await registry.cancelMeeting({
@@ -375,7 +380,7 @@ describe("OpenClawTapRegistry", () => {
 			reason: "Conflict",
 		});
 
-		expect(cancelPendingSchedulingRequest).toHaveBeenCalledWith("outbound-entry", "Conflict");
+		expect(cancelMeeting).toHaveBeenCalledWith("sch-cancel-1", "Conflict");
 		expect(result).toMatchObject({
 			identity: "alpha",
 			cancelled: true,


### PR DESCRIPTION
## Summary

Nine bug fixes across three commits on this branch plus one follow-up that makes the new XMTP reconcile error handling observable.

### Commit 1 (bf984a4) — reconcile abort, cancelMeeting, cross-chain transfer (CLI)
- `XmtpTransport.reconcile` now skips a single failing DM instead of aborting the whole pass.
- `openclaw-plugin` `cancelMeeting` delegates to `TapMessagingService.cancelMeeting` so accepted meetings can actually be cancelled.
- CLI `executeTransfer` hook passes `request.chain` into `createConfiguredSigningProvider` so cross-chain transfers sign on the right chain.

### Commit 2 (11714f9) — per-message reconcile, cross-chain transfer (plugin), reconcile timer
- `reconcileConversation` wraps per-message processing in try/catch and leaves the checkpoint untouched on failure so transient errors can be retried.
- Plugin `transfer` action builds a per-chain `OwsSigningProvider` when `params.chain !== runtime.config.chain`.
- `ensureRuntimeStarted` only calls `startRuntime` when no interval is running, so repeated action calls no longer reset the periodic reconcile timer.

### Commit 3 (a17b095) — immediate app result delivery, non-TTY meeting safety, connect wait math
- `dispatchToApp` now builds a `PendingActionResultDelivery`, persists the outbound journal entry, and delivers immediately — removing the prior reconcile-interval latency for non-builtin app responses.
- CLI `confirmMeeting` returns `false` in non-TTY mode instead of auto-approving without user consent.
- `connect` command subtracts elapsed time from `waitMs` before calling `pollForActiveContact` so the effective wait is no longer doubled.

### Commit 4 (this PR) — observable reconcile errors
Follow-up on review feedback: the two `catch {}` blocks from commits #1 and #2 are necessary (distinct DM-level vs. per-message failure modes) but silently swallowed errors. They now capture error counts and sample messages and surface them via `TransportReconcileResult`. `TapMessagingService.runReconcile` logs a warning when `errors > 0`. The `errors` field is only populated when non-zero so existing `toEqual({synced, processed})` tests keep passing.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — all passing tests from this suite remain green; two pre-existing flaky tests (`service.waiters.test.ts`, `service.auto-accept.test.ts`) are unchanged by this branch and reproduce on the baseline.
- [x] `bun run test -- packages/core/test/unit/transport/xmtp.test.ts` (33 passing)
- [ ] Smoke test an OpenClaw plugin reconcile pass with a forced DM-level failure to confirm the warning logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transport reconciliation, action-result delivery, and approval/cancellation flows; failures could affect message processing reliability or user-consent behavior. Changes are localized and add logging/guardrails, but impact core runtime/transport paths.
> 
> **Overview**
> Improves XMTP reconcile robustness by isolating failures to a single DM or message, preserving checkpoints on per-message errors, and surfacing reconcile `errors` + sample messages via `TransportReconcileResult` (with a warning log in `TapMessagingService.runReconcile`).
> 
> Fixes user-facing workflow bugs: `tap connect` now polls using the *remaining* wait time (avoids double-wait), CLI meeting confirmation no longer auto-confirms in non-TTY mode, and `openclaw-plugin` cancellation now delegates to `service.cancelMeeting` so accepted meetings can be cancelled.
> 
> Addresses cross-chain transfers by selecting a signing provider per `request.chain` (CLI + OpenClaw plugin), prevents plugin actions from restarting the periodic reconcile timer unnecessarily, and delivers non-builtin app `action/result` responses immediately after journaling (instead of waiting for reconcile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb4e30bd9f07c4e8914bed75045baf303fcbb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->