### PR TITLE
feat(cli): add host-aware `tap status` for first-step debugging

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -145,6 +145,31 @@ export function createCli(): Command {
 		});
 
 	program
+		.command("status")
+		.description("Show host-aware runtime state for the current TAP data dir")
+		.option("--hermes-home <path>", "Override HERMES_HOME for the Hermes integration probe")
+		.addHelpText(
+			"after",
+			`
+First-step debug command. Reports which host is managing the data dir
+(CLI listener, Hermes daemon, OpenClaw plugin, or idle), who currently
+owns the transport lock, contact state (handshake), message/send state
+(actual peer communication), and journal pending work. All reads are
+filesystem-only: no transport is started.
+
+Examples:
+  tap status
+  tap status --data-dir /path/to/agent
+  tap status --json
+`,
+		)
+		.action(async (cmdOpts: { hermesHome?: string }) => {
+			const opts = program.opts<GlobalOptions>();
+			const { statusCommand } = await import("./commands/status.js");
+			await statusCommand(cmdOpts, opts);
+		});
+
+	program
 		.command("remove")
 		.description("Remove local TAP agent data")
 		.option("--dry-run", "Show the local TAP files and directories that would be removed")

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -340,14 +340,22 @@ function formatReadError(err: unknown): string {
 }
 
 function isConversationLog(value: unknown): value is ConversationLog {
-	// Minimal shape check — just enough so `summarizeMessages` can iterate
-	// safely. A file like `{}` or `{"messages": null}` is schema-invalid and
-	// must be counted as "unreadable" rather than crashing the whole command.
+	// Shape check must be strict enough that every field summarizeMessages
+	// dereferences (`messages[i].direction`, `messages[i].timestamp`) is safe.
+	// A file like `{}`, `{"messages": null}`, or even
+	// `{"messages": [null]}` must be counted as "unreadable" rather than
+	// crashing the whole command during iteration.
 	if (typeof value !== "object" || value === null) return false;
 	const record = value as Record<string, unknown>;
 	if (!Array.isArray(record.messages)) return false;
 	if (typeof record.peerAgentId !== "number") return false;
 	if (typeof record.peerDisplayName !== "string") return false;
+	for (const message of record.messages) {
+		if (typeof message !== "object" || message === null) return false;
+		const entry = message as Record<string, unknown>;
+		if (entry.direction !== "incoming" && entry.direction !== "outgoing") return false;
+		if (typeof entry.timestamp !== "string") return false;
+	}
 	return true;
 }
 
@@ -608,8 +616,16 @@ function buildWarnings(input: {
 	// belongs to a dead process. A truthy-but-`alive: false` owner must NOT
 	// swallow this warning — the operator needs to see both the stale-lock
 	// note and the "nothing is draining your queue" note.
+	//
+	// BUT: when the lock file itself is unreadable, ownership is *unknown*
+	// rather than idle. A live host may well be draining the queue through a
+	// process we just can't inspect. In that case the broken-lock warning is
+	// already telling the operator what's wrong; we must not additionally
+	// claim "nothing is draining your queue" because that can be a false
+	// diagnosis.
+	const transportOwnershipKnown = input.readErrors.transportOwner === undefined;
 	const transportIdle = !input.transportOwner || !input.transportOwner.alive;
-	if (input.journalSummary.queued_commands > 0 && transportIdle) {
+	if (input.journalSummary.queued_commands > 0 && transportIdle && transportOwnershipKnown) {
 		warnings.push(
 			`${input.journalSummary.queued_commands} queued command(s) in journal but no live transport owner is draining them. Start \`tap message listen\` or restart the host that owns this data dir.`,
 		);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,15 +1,17 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve as resolvePath } from "node:path";
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve as resolvePath } from "node:path";
 import {
 	type Contact,
 	type ConversationLog,
-	FileConversationLogger,
 	FileRequestJournal,
 	FileTrustStore,
 	type RequestJournalEntry,
 	type TransportOwnerInfo,
 	TransportOwnerLock,
+	fsErrorCode,
 	isProcessAlive,
+	resolveDataDir as resolveDataDirPath,
 } from "trusted-agents-core";
 import YAML from "yaml";
 import { readHermesTapDaemonState } from "../hermes/client.js";
@@ -104,6 +106,8 @@ interface HermesStatus {
 	configured_identities: string[];
 	/** Populated when the plugin config exists but cannot be parsed. */
 	config_error?: string;
+	/** Populated when daemon.json exists but cannot be parsed. */
+	daemon_state_error?: string;
 }
 
 interface MessageSummary {
@@ -271,11 +275,46 @@ async function readJournal(dataDir: string): Promise<ReadResult<RequestJournalEn
 }
 
 async function readConversations(dataDir: string): Promise<ReadResult<ConversationLog[]>> {
+	// `FileConversationLogger.listConversations()` silently swallows per-file
+	// JSON parse errors and skips them (see logger.ts `// Skip corrupted files`
+	// branch). For a diagnostic command that's a footgun — one corrupt file
+	// silently undercounts messages without any warning. So we do our own scan
+	// here, track the per-file failures, and surface them as a readable error
+	// if any file couldn't be parsed.
+	const conversationsDir = join(resolveDataDirPath(dataDir), "conversations");
+	let entries: string[];
 	try {
-		return { value: await new FileConversationLogger(dataDir).listConversations() };
+		entries = await readdir(conversationsDir);
 	} catch (err) {
+		if (fsErrorCode(err) === "ENOENT") {
+			return { value: [] };
+		}
 		return { value: [], error: formatReadError(err) };
 	}
+
+	const value: ConversationLog[] = [];
+	const failed: string[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".json")) continue;
+		const filePath = join(conversationsDir, entry);
+		try {
+			const raw = await readFile(filePath, "utf-8");
+			value.push(JSON.parse(raw) as ConversationLog);
+		} catch {
+			failed.push(entry);
+		}
+	}
+
+	if (failed.length === 0) {
+		return { value };
+	}
+
+	const sample = failed.slice(0, 3).join(", ");
+	const suffix = failed.length > 3 ? `, +${failed.length - 3} more` : "";
+	return {
+		value,
+		error: `${failed.length} conversation file(s) unreadable: ${sample}${suffix}`,
+	};
 }
 
 function formatReadError(err: unknown): string {
@@ -288,11 +327,16 @@ async function readHermesStatus(
 ): Promise<HermesStatus | null> {
 	const hermesHome = resolveHermesHome(hermesHomeOverride);
 
+	// `loadTapHermesDaemonState` treats ENOENT as "no daemon running" but throws
+	// on JSON-parse / non-ENOENT I/O failures. We must distinguish those so a
+	// malformed daemon.json shows up as a warning instead of looking exactly
+	// like "Hermes is not running".
 	let daemonState: TapHermesDaemonState | null = null;
+	let daemonStateError: string | undefined;
 	try {
 		daemonState = await readHermesTapDaemonState(hermesHome);
-	} catch {
-		daemonState = null;
+	} catch (err) {
+		daemonStateError = formatReadError(err);
 	}
 
 	let config: TapHermesPluginConfig | null = null;
@@ -306,33 +350,36 @@ async function readHermesStatus(
 		configError = formatReadError(err);
 	}
 
-	if (!config && !configError && !daemonState) {
-		// No config file, no broken config, no daemon state — genuinely not
-		// installed for this user.
+	if (!config && !configError && !daemonState && !daemonStateError) {
+		// No config file, no broken config, no daemon state, no broken daemon
+		// state — genuinely not installed for this user.
 		return null;
 	}
 
+	const daemonRunning = daemonState ? isProcessAlive(daemonState.pid) : false;
+
 	if (!config) {
-		// We got here because configError is set OR a daemon state file exists.
-		// In either case treat Hermes as installed so the error/daemon warning
+		// We got here because configError OR a daemon state signal is present.
+		// Either way, treat Hermes as installed so the error/daemon warning
 		// paths still fire.
 		return {
 			installed: true,
-			daemon_running: daemonState ? isProcessAlive(daemonState.pid) : false,
+			daemon_running: daemonRunning,
 			daemon_pid: daemonState?.pid ?? null,
 			gateway_pid: daemonState?.gatewayPid ?? null,
 			manages_this_data_dir: false,
 			configured_identities: [],
 			...(configError ? { config_error: configError } : {}),
+			...(daemonStateError ? { daemon_state_error: daemonStateError } : {}),
 		};
 	}
 
-	const daemonRunning = daemonState ? isProcessAlive(daemonState.pid) : false;
 	const normalizedDataDir = resolvePath(dataDir);
 	const managesThisDataDir = config.identities.some(
 		(identity) => resolvePath(identity.dataDir) === normalizedDataDir,
 	);
-	const installed = config.identities.length > 0 || daemonState !== null;
+	const installed =
+		config.identities.length > 0 || daemonState !== null || daemonStateError !== undefined;
 
 	if (!installed) {
 		return null;
@@ -345,6 +392,7 @@ async function readHermesStatus(
 		gateway_pid: daemonState?.gatewayPid ?? null,
 		manages_this_data_dir: managesThisDataDir,
 		configured_identities: config.identities.map((identity) => identity.name),
+		...(daemonStateError ? { daemon_state_error: daemonStateError } : {}),
 	};
 }
 
@@ -538,6 +586,12 @@ function buildWarnings(input: {
 	if (input.hermes?.config_error) {
 		warnings.push(
 			`Hermes TAP plugin config exists but cannot be parsed: ${input.hermes.config_error}. Fix it or re-run \`tap hermes configure\`.`,
+		);
+	}
+
+	if (input.hermes?.daemon_state_error) {
+		warnings.push(
+			`Hermes TAP daemon state file exists but cannot be parsed: ${input.hermes.daemon_state_error}. The daemon running state is unknown until this is resolved.`,
 		);
 	}
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,478 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import {
+	type Contact,
+	type ConversationLog,
+	FileConversationLogger,
+	FileRequestJournal,
+	FileTrustStore,
+	type RequestJournalEntry,
+	type TransportOwnerInfo,
+	TransportOwnerLock,
+	isProcessAlive,
+} from "trusted-agents-core";
+import YAML from "yaml";
+import { readHermesTapDaemonState } from "../hermes/client.js";
+import {
+	type TapHermesDaemonState,
+	type TapHermesPluginConfig,
+	loadTapHermesPluginConfig,
+	resolveHermesHome,
+} from "../hermes/config.js";
+import {
+	resolveConfigPath,
+	resolveDataDir,
+	validateConfigPathInDataDir,
+} from "../lib/config-loader.js";
+import { handleCommandError } from "../lib/errors.js";
+import { success } from "../lib/output.js";
+import type { GlobalOptions } from "../types.js";
+
+const STUCK_CONNECTING_THRESHOLD_MINUTES = 5;
+
+type HostMode =
+	| "not-initialized"
+	| "config-invalid"
+	| "not-registered"
+	| "idle"
+	| "cli-listener"
+	| "cli-transient"
+	| "hermes-managed"
+	| "openclaw-managed"
+	| "unknown-owner";
+
+type ConfigState =
+	| { kind: "missing" }
+	| { kind: "invalid"; error: string }
+	| { kind: "parsed"; agentId: number | null; chain: string | null };
+
+interface StatusPayload {
+	data_dir: string;
+	config: {
+		exists: boolean;
+		valid: boolean;
+		agent_id: number | null;
+		chain: string | null;
+		registered: boolean;
+	};
+	host: {
+		mode: HostMode;
+		transport_owner:
+			| (TransportOwnerInfo & {
+					alive: boolean;
+			  })
+			| null;
+		hermes: HermesStatus | null;
+	};
+	contacts: {
+		total: number;
+		active: number;
+		connecting: number;
+		oldest_connecting: {
+			peer: string;
+			established_at: string;
+			age_minutes: number;
+		} | null;
+	};
+	messages: {
+		inbound_count: number;
+		outbound_count: number;
+		last_inbound: MessageSummary | null;
+		last_outbound: MessageSummary | null;
+	};
+	journal: {
+		inbound_pending: number;
+		outbound_pending: number;
+		queued_commands: number;
+		oldest_pending: {
+			request_id: string;
+			method: string;
+			direction: "inbound" | "outbound";
+			age_minutes: number;
+			last_error?: string;
+		} | null;
+	};
+	warnings: string[];
+}
+
+interface HermesStatus {
+	installed: boolean;
+	daemon_running: boolean;
+	daemon_pid: number | null;
+	gateway_pid: number | null;
+	manages_this_data_dir: boolean;
+	configured_identities: string[];
+}
+
+interface MessageSummary {
+	peer: string;
+	peer_agent_id: number;
+	at: string;
+}
+
+interface StatusFlags {
+	hermesHome?: string;
+}
+
+export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Promise<void> {
+	const startTime = Date.now();
+
+	try {
+		const dataDir = resolveDataDir(opts);
+		const configPath = resolveConfigPath(opts, dataDir);
+		// Prevent an internally inconsistent status where --data-dir points at
+		// agent A but --config reads from agent B.
+		validateConfigPathInDataDir(opts, configPath, dataDir);
+
+		const configState = readConfigState(configPath);
+		const registered =
+			configState.kind === "parsed" && configState.agentId !== null && configState.agentId >= 0;
+
+		const ownerInspector = new TransportOwnerLock(dataDir, "tap:status");
+		const rawOwner = await ownerInspector.inspect();
+		const ownerAlive = rawOwner ? isProcessAlive(rawOwner.pid) : false;
+		const transportOwner = rawOwner ? { ...rawOwner, alive: ownerAlive } : null;
+
+		const contacts = await readContacts(dataDir);
+		const journalEntries = await readJournal(dataDir);
+		const conversations = await readConversations(dataDir);
+		const hermes = await readHermesStatus(flags.hermesHome, dataDir);
+
+		const mode = detectMode({
+			configState,
+			registered,
+			transportOwner,
+		});
+
+		const contactsSummary = summarizeContacts(contacts);
+		const messages = summarizeMessages(conversations);
+		const journalSummary = summarizeJournal(journalEntries);
+
+		const warnings = buildWarnings({
+			configState,
+			registered,
+			transportOwner,
+			contactsSummary,
+			journalSummary,
+			hermes,
+		});
+
+		const payload: StatusPayload = {
+			data_dir: dataDir,
+			config: {
+				exists: configState.kind !== "missing",
+				valid: configState.kind === "parsed",
+				agent_id: configState.kind === "parsed" ? configState.agentId : null,
+				chain: configState.kind === "parsed" ? configState.chain : null,
+				registered,
+			},
+			host: {
+				mode,
+				transport_owner: transportOwner,
+				hermes,
+			},
+			contacts: contactsSummary,
+			messages,
+			journal: journalSummary,
+			warnings,
+		};
+
+		success(payload, opts, startTime);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+function readConfigState(configPath: string): ConfigState {
+	if (!existsSync(configPath)) {
+		return { kind: "missing" };
+	}
+
+	let raw: string;
+	try {
+		raw = readFileSync(configPath, "utf-8");
+	} catch (err) {
+		return { kind: "invalid", error: err instanceof Error ? err.message : String(err) };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = YAML.parse(raw);
+	} catch (err) {
+		return { kind: "invalid", error: err instanceof Error ? err.message : String(err) };
+	}
+
+	if (parsed === null || parsed === undefined) {
+		// Empty file. Treat as present-but-unusable so we don't fake registration.
+		return { kind: "invalid", error: "config.yaml is empty" };
+	}
+
+	if (typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { kind: "invalid", error: "config.yaml must be a YAML mapping" };
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const rawAgentId = record.agent_id;
+	let agentId: number | null;
+	if (rawAgentId === undefined || rawAgentId === null) {
+		// Field absent entirely — distinct from "present but -1". Treat as not
+		// registered without inventing a concrete id.
+		agentId = null;
+	} else if (typeof rawAgentId === "number" && Number.isFinite(rawAgentId)) {
+		agentId = rawAgentId;
+	} else {
+		return {
+			kind: "invalid",
+			error: `config.yaml agent_id must be a finite number (got ${typeof rawAgentId})`,
+		};
+	}
+
+	const rawChain = record.chain;
+	const chain = typeof rawChain === "string" && rawChain.length > 0 ? rawChain : null;
+
+	return { kind: "parsed", agentId, chain };
+}
+
+async function readContacts(dataDir: string): Promise<Contact[]> {
+	try {
+		return await new FileTrustStore(dataDir).getContacts();
+	} catch {
+		return [];
+	}
+}
+
+async function readJournal(dataDir: string): Promise<RequestJournalEntry[]> {
+	try {
+		return await new FileRequestJournal(dataDir).list();
+	} catch {
+		return [];
+	}
+}
+
+async function readConversations(dataDir: string): Promise<ConversationLog[]> {
+	try {
+		return await new FileConversationLogger(dataDir).listConversations();
+	} catch {
+		return [];
+	}
+}
+
+async function readHermesStatus(
+	hermesHomeOverride: string | undefined,
+	dataDir: string,
+): Promise<HermesStatus | null> {
+	const hermesHome = resolveHermesHome(hermesHomeOverride);
+	let config: TapHermesPluginConfig;
+	try {
+		config = await loadTapHermesPluginConfig(hermesHome);
+	} catch {
+		return null;
+	}
+
+	let daemonState: TapHermesDaemonState | null = null;
+	try {
+		daemonState = await readHermesTapDaemonState(hermesHome);
+	} catch {
+		daemonState = null;
+	}
+
+	const daemonRunning = daemonState ? isProcessAlive(daemonState.pid) : false;
+	const normalizedDataDir = resolvePath(dataDir);
+	const managesThisDataDir = config.identities.some(
+		(identity) => resolvePath(identity.dataDir) === normalizedDataDir,
+	);
+	const installed = config.identities.length > 0 || daemonState !== null;
+
+	if (!installed) {
+		return null;
+	}
+
+	return {
+		installed,
+		daemon_running: daemonRunning,
+		daemon_pid: daemonState?.pid ?? null,
+		gateway_pid: daemonState?.gatewayPid ?? null,
+		manages_this_data_dir: managesThisDataDir,
+		configured_identities: config.identities.map((identity) => identity.name),
+	};
+}
+
+function detectMode(input: {
+	configState: ConfigState;
+	registered: boolean;
+	transportOwner: (TransportOwnerInfo & { alive: boolean }) | null;
+}): HostMode {
+	if (input.configState.kind === "missing") return "not-initialized";
+	if (input.configState.kind === "invalid") return "config-invalid";
+	if (!input.registered) return "not-registered";
+
+	const owner = input.transportOwner;
+	if (!owner || !owner.alive) return "idle";
+
+	if (owner.owner.startsWith("hermes:")) return "hermes-managed";
+	if (owner.owner.startsWith("openclaw:")) return "openclaw-managed";
+	if (owner.owner === "tap:listen") return "cli-listener";
+	if (owner.owner.startsWith("tap:")) return "cli-transient";
+	return "unknown-owner";
+}
+
+function summarizeContacts(contacts: Contact[]): StatusPayload["contacts"] {
+	const active = contacts.filter((c) => c.status === "active").length;
+	const connecting = contacts.filter((c) => c.status === "connecting");
+	const oldestConnecting = connecting
+		.slice()
+		.sort((a, b) => a.establishedAt.localeCompare(b.establishedAt))[0];
+
+	return {
+		total: contacts.length,
+		active,
+		connecting: connecting.length,
+		oldest_connecting: oldestConnecting
+			? {
+					peer: `${oldestConnecting.peerDisplayName} (#${oldestConnecting.peerAgentId})`,
+					established_at: oldestConnecting.establishedAt,
+					age_minutes: ageMinutes(oldestConnecting.establishedAt),
+				}
+			: null,
+	};
+}
+
+function summarizeMessages(conversations: ConversationLog[]): StatusPayload["messages"] {
+	// Conversation logs are the source of truth for "did any actual peer
+	// communication happen?". `sendMessageInternal` writes to conversations
+	// but does NOT add a message/send row to the request journal, so counting
+	// from the journal silently drops every successful outbound send.
+	// Conversations capture both message/send and action/* traffic, which is
+	// exactly what "real peer messages" means for a debug-first command —
+	// handshake traffic (connection/*) is not logged there.
+	let inbound = 0;
+	let outbound = 0;
+	let latestIn: { entry: MessageSummary } | null = null;
+	let latestOut: { entry: MessageSummary } | null = null;
+
+	for (const log of conversations) {
+		const peerLabel = `${log.peerDisplayName} (#${log.peerAgentId})`;
+		for (const message of log.messages) {
+			if (message.direction === "incoming") {
+				inbound += 1;
+				if (!latestIn || message.timestamp > latestIn.entry.at) {
+					latestIn = {
+						entry: { peer: peerLabel, peer_agent_id: log.peerAgentId, at: message.timestamp },
+					};
+				}
+			} else if (message.direction === "outgoing") {
+				outbound += 1;
+				if (!latestOut || message.timestamp > latestOut.entry.at) {
+					latestOut = {
+						entry: { peer: peerLabel, peer_agent_id: log.peerAgentId, at: message.timestamp },
+					};
+				}
+			}
+		}
+	}
+
+	return {
+		inbound_count: inbound,
+		outbound_count: outbound,
+		last_inbound: latestIn?.entry ?? null,
+		last_outbound: latestOut?.entry ?? null,
+	};
+}
+
+function summarizeJournal(entries: RequestJournalEntry[]): StatusPayload["journal"] {
+	const nonCompleted = entries.filter((e) => e.status !== "completed");
+	const inboundPending = nonCompleted.filter((e) => e.direction === "inbound").length;
+	const outboundPending = nonCompleted.filter((e) => e.direction === "outbound").length;
+	const queuedCommands = entries.filter(
+		(e) => e.status === "queued" && e.method.startsWith("command/"),
+	).length;
+
+	const oldest = nonCompleted.slice().sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
+
+	return {
+		inbound_pending: inboundPending,
+		outbound_pending: outboundPending,
+		queued_commands: queuedCommands,
+		oldest_pending: oldest
+			? {
+					request_id: oldest.requestId,
+					method: oldest.method,
+					direction: oldest.direction,
+					age_minutes: ageMinutes(oldest.createdAt),
+					...(oldest.metadata?.lastError?.message
+						? { last_error: oldest.metadata.lastError.message }
+						: {}),
+				}
+			: null,
+	};
+}
+
+function buildWarnings(input: {
+	configState: ConfigState;
+	registered: boolean;
+	transportOwner: (TransportOwnerInfo & { alive: boolean }) | null;
+	contactsSummary: StatusPayload["contacts"];
+	journalSummary: StatusPayload["journal"];
+	hermes: HermesStatus | null;
+}): string[] {
+	const warnings: string[] = [];
+
+	if (input.configState.kind === "missing") {
+		warnings.push("No TAP config at this data dir. Run `tap init` to create one.");
+		return warnings;
+	}
+
+	if (input.configState.kind === "invalid") {
+		warnings.push(
+			`config.yaml exists but cannot be parsed: ${input.configState.error}. Fix it by hand or re-run \`tap init\`.`,
+		);
+		return warnings;
+	}
+
+	if (!input.registered) {
+		warnings.push(
+			"Agent has no on-chain identity yet (agent_id missing or < 0). Run `tap register` to finish onboarding.",
+		);
+	}
+
+	if (input.transportOwner && !input.transportOwner.alive) {
+		warnings.push(
+			`Stale transport lock: ${input.transportOwner.owner} (pid ${input.transportOwner.pid}) is not running. The next transport-active command will recover it automatically.`,
+		);
+	}
+
+	if (
+		input.contactsSummary.oldest_connecting &&
+		input.contactsSummary.oldest_connecting.age_minutes >= STUCK_CONNECTING_THRESHOLD_MINUTES
+	) {
+		warnings.push(
+			`Contact ${input.contactsSummary.oldest_connecting.peer} has been in 'connecting' state for ${input.contactsSummary.oldest_connecting.age_minutes} minutes. Try \`tap message sync\`.`,
+		);
+	}
+
+	if (input.journalSummary.queued_commands > 0 && !input.transportOwner) {
+		warnings.push(
+			`${input.journalSummary.queued_commands} queued command(s) in journal but no transport owner is draining them. Start \`tap message listen\` or restart the host that owns this data dir.`,
+		);
+	}
+
+	if (input.hermes?.daemon_running && !input.hermes.manages_this_data_dir) {
+		warnings.push(
+			"Hermes TAP daemon is running but this data-dir is not in its configured identities. If you expected Hermes to own this agent's transport, run `tap hermes configure --name <name>` from this data dir.",
+		);
+	}
+
+	if (input.hermes?.manages_this_data_dir && !input.hermes.daemon_running) {
+		warnings.push(
+			"Hermes is configured to manage this data-dir but the TAP daemon is not running. Start or restart `hermes gateway`.",
+		);
+	}
+
+	return warnings;
+}
+
+function ageMinutes(iso: string): number {
+	const t = Date.parse(iso);
+	if (!Number.isFinite(t)) return 0;
+	return Math.max(0, Math.round((Date.now() - t) / 60_000));
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -643,13 +643,28 @@ function buildWarnings(input: {
 		);
 	}
 
-	if (input.hermes?.daemon_running && !input.hermes.manages_this_data_dir) {
+	// The identity-mismatch and daemon-not-running warnings rely on `config`
+	// and `daemon_state` being readable. When either is broken, we already
+	// emit a dedicated warning pointing at the real problem — adding a
+	// contradictory downstream diagnosis ("daemon is not running" when we
+	// can't actually tell, or "not in configured identities" when we just
+	// couldn't parse the identities list) just confuses the operator. Gate
+	// on the same "is ownership actually known?" pattern the transport-lock
+	// queued-commands warning uses.
+	const hermesConfigReadable = input.hermes?.config_error === undefined;
+	const hermesDaemonStateReadable = input.hermes?.daemon_state_error === undefined;
+
+	if (input.hermes?.daemon_running && !input.hermes.manages_this_data_dir && hermesConfigReadable) {
 		warnings.push(
 			"Hermes TAP daemon is running but this data-dir is not in its configured identities. If you expected Hermes to own this agent's transport, run `tap hermes configure --name <name>` from this data dir.",
 		);
 	}
 
-	if (input.hermes?.manages_this_data_dir && !input.hermes.daemon_running) {
+	if (
+		input.hermes?.manages_this_data_dir &&
+		!input.hermes.daemon_running &&
+		hermesDaemonStateReadable
+	) {
 		warnings.push(
 			"Hermes is configured to manage this data-dir but the TAP daemon is not running. Start or restart `hermes gateway`.",
 		);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -102,12 +102,19 @@ interface HermesStatus {
 	gateway_pid: number | null;
 	manages_this_data_dir: boolean;
 	configured_identities: string[];
+	/** Populated when the plugin config exists but cannot be parsed. */
+	config_error?: string;
 }
 
 interface MessageSummary {
 	peer: string;
 	peer_agent_id: number;
 	at: string;
+}
+
+interface ReadResult<T> {
+	value: T;
+	error?: string;
 }
 
 interface StatusFlags {
@@ -133,9 +140,9 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 		const ownerAlive = rawOwner ? isProcessAlive(rawOwner.pid) : false;
 		const transportOwner = rawOwner ? { ...rawOwner, alive: ownerAlive } : null;
 
-		const contacts = await readContacts(dataDir);
-		const journalEntries = await readJournal(dataDir);
-		const conversations = await readConversations(dataDir);
+		const contactsRead = await readContacts(dataDir);
+		const journalRead = await readJournal(dataDir);
+		const conversationsRead = await readConversations(dataDir);
 		const hermes = await readHermesStatus(flags.hermesHome, dataDir);
 
 		const mode = detectMode({
@@ -144,9 +151,9 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 			transportOwner,
 		});
 
-		const contactsSummary = summarizeContacts(contacts);
-		const messages = summarizeMessages(conversations);
-		const journalSummary = summarizeJournal(journalEntries);
+		const contactsSummary = summarizeContacts(contactsRead.value);
+		const messages = summarizeMessages(conversationsRead.value);
+		const journalSummary = summarizeJournal(journalRead.value);
 
 		const warnings = buildWarnings({
 			configState,
@@ -155,6 +162,11 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 			contactsSummary,
 			journalSummary,
 			hermes,
+			readErrors: {
+				contacts: contactsRead.error,
+				journal: journalRead.error,
+				conversations: conversationsRead.error,
+			},
 		});
 
 		const payload: StatusPayload = {
@@ -233,28 +245,41 @@ function readConfigState(configPath: string): ConfigState {
 	return { kind: "parsed", agentId, chain };
 }
 
-async function readContacts(dataDir: string): Promise<Contact[]> {
+// ── Readers ──
+//
+// Each reader returns `{ value, error? }` so callers can distinguish "source is
+// empty" from "source is corrupt/unreadable". Collapsing both into `[]` turns
+// genuine file corruption into a fake "healthy" state — which is exactly when
+// the operator runs `tap status` for diagnosis. The underlying File* stores
+// already treat missing files as empty via ENOENT, so any error surfaced here
+// is a real JSON-parse or I/O failure worth warning about.
+
+async function readContacts(dataDir: string): Promise<ReadResult<Contact[]>> {
 	try {
-		return await new FileTrustStore(dataDir).getContacts();
-	} catch {
-		return [];
+		return { value: await new FileTrustStore(dataDir).getContacts() };
+	} catch (err) {
+		return { value: [], error: formatReadError(err) };
 	}
 }
 
-async function readJournal(dataDir: string): Promise<RequestJournalEntry[]> {
+async function readJournal(dataDir: string): Promise<ReadResult<RequestJournalEntry[]>> {
 	try {
-		return await new FileRequestJournal(dataDir).list();
-	} catch {
-		return [];
+		return { value: await new FileRequestJournal(dataDir).list() };
+	} catch (err) {
+		return { value: [], error: formatReadError(err) };
 	}
 }
 
-async function readConversations(dataDir: string): Promise<ConversationLog[]> {
+async function readConversations(dataDir: string): Promise<ReadResult<ConversationLog[]>> {
 	try {
-		return await new FileConversationLogger(dataDir).listConversations();
-	} catch {
-		return [];
+		return { value: await new FileConversationLogger(dataDir).listConversations() };
+	} catch (err) {
+		return { value: [], error: formatReadError(err) };
 	}
+}
+
+function formatReadError(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
 }
 
 async function readHermesStatus(
@@ -262,18 +287,44 @@ async function readHermesStatus(
 	dataDir: string,
 ): Promise<HermesStatus | null> {
 	const hermesHome = resolveHermesHome(hermesHomeOverride);
-	let config: TapHermesPluginConfig;
-	try {
-		config = await loadTapHermesPluginConfig(hermesHome);
-	} catch {
-		return null;
-	}
 
 	let daemonState: TapHermesDaemonState | null = null;
 	try {
 		daemonState = await readHermesTapDaemonState(hermesHome);
 	} catch {
 		daemonState = null;
+	}
+
+	let config: TapHermesPluginConfig | null = null;
+	let configError: string | undefined;
+	try {
+		config = await loadTapHermesPluginConfig(hermesHome);
+	} catch (err) {
+		// The config file exists but is unreadable or malformed. Report this
+		// as "installed but broken" so the operator sees the root cause instead
+		// of a false "Hermes isn't installed" silence.
+		configError = formatReadError(err);
+	}
+
+	if (!config && !configError && !daemonState) {
+		// No config file, no broken config, no daemon state — genuinely not
+		// installed for this user.
+		return null;
+	}
+
+	if (!config) {
+		// We got here because configError is set OR a daemon state file exists.
+		// In either case treat Hermes as installed so the error/daemon warning
+		// paths still fire.
+		return {
+			installed: true,
+			daemon_running: daemonState ? isProcessAlive(daemonState.pid) : false,
+			daemon_pid: daemonState?.pid ?? null,
+			gateway_pid: daemonState?.gatewayPid ?? null,
+			manages_this_data_dir: false,
+			configured_identities: [],
+			...(configError ? { config_error: configError } : {}),
+		};
 	}
 
 	const daemonRunning = daemonState ? isProcessAlive(daemonState.pid) : false;
@@ -414,8 +465,31 @@ function buildWarnings(input: {
 	contactsSummary: StatusPayload["contacts"];
 	journalSummary: StatusPayload["journal"];
 	hermes: HermesStatus | null;
+	readErrors: {
+		contacts?: string;
+		journal?: string;
+		conversations?: string;
+	};
 }): string[] {
 	const warnings: string[] = [];
+
+	// Surface read failures first — if a store is unreadable, every other
+	// derived metric is silently zero and would mislead the operator.
+	if (input.readErrors.contacts) {
+		warnings.push(
+			`Failed to read contacts.json: ${input.readErrors.contacts}. Contact counts are incomplete.`,
+		);
+	}
+	if (input.readErrors.journal) {
+		warnings.push(
+			`Failed to read request-journal.json: ${input.readErrors.journal}. Journal counts are incomplete.`,
+		);
+	}
+	if (input.readErrors.conversations) {
+		warnings.push(
+			`Failed to read conversations/: ${input.readErrors.conversations}. Message counts are incomplete.`,
+		);
+	}
 
 	if (input.configState.kind === "missing") {
 		warnings.push("No TAP config at this data dir. Run `tap init` to create one.");
@@ -450,9 +524,20 @@ function buildWarnings(input: {
 		);
 	}
 
-	if (input.journalSummary.queued_commands > 0 && !input.transportOwner) {
+	// Queued commands are equally undrained whether no lock exists OR the lock
+	// belongs to a dead process. A truthy-but-`alive: false` owner must NOT
+	// swallow this warning — the operator needs to see both the stale-lock
+	// note and the "nothing is draining your queue" note.
+	const transportIdle = !input.transportOwner || !input.transportOwner.alive;
+	if (input.journalSummary.queued_commands > 0 && transportIdle) {
 		warnings.push(
-			`${input.journalSummary.queued_commands} queued command(s) in journal but no transport owner is draining them. Start \`tap message listen\` or restart the host that owns this data dir.`,
+			`${input.journalSummary.queued_commands} queued command(s) in journal but no live transport owner is draining them. Start \`tap message listen\` or restart the host that owns this data dir.`,
+		);
+	}
+
+	if (input.hermes?.config_error) {
+		warnings.push(
+			`Hermes TAP plugin config exists but cannot be parsed: ${input.hermes.config_error}. Fix it or re-run \`tap hermes configure\`.`,
 		);
 	}
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -37,6 +37,7 @@ type HostMode =
 	| "config-invalid"
 	| "not-registered"
 	| "idle"
+	| "transport-unknown"
 	| "cli-listener"
 	| "cli-transient"
 	| "hermes-managed"
@@ -165,6 +166,7 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 			configState,
 			registered,
 			transportOwner,
+			transportOwnerError,
 		});
 
 		const contactsSummary = summarizeContacts(contactsRead.value);
@@ -434,10 +436,16 @@ function detectMode(input: {
 	configState: ConfigState;
 	registered: boolean;
 	transportOwner: (TransportOwnerInfo & { alive: boolean }) | null;
+	transportOwnerError: string | undefined;
 }): HostMode {
 	if (input.configState.kind === "missing") return "not-initialized";
 	if (input.configState.kind === "invalid") return "config-invalid";
 	if (!input.registered) return "not-registered";
+
+	// A read failure on `.transport.lock` means ownership is unknown, NOT
+	// idle. Automation / JSON consumers that key off `mode` must not be told
+	// "idle" when we explicitly couldn't read the lock file.
+	if (input.transportOwnerError !== undefined) return "transport-unknown";
 
 	const owner = input.transportOwner;
 	if (!owner || !owner.alive) return "idle";

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -139,10 +139,22 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 		const registered =
 			configState.kind === "parsed" && configState.agentId !== null && configState.agentId >= 0;
 
-		const ownerInspector = new TransportOwnerLock(dataDir, "tap:status");
-		const rawOwner = await ownerInspector.inspect();
-		const ownerAlive = rawOwner ? isProcessAlive(rawOwner.pid) : false;
-		const transportOwner = rawOwner ? { ...rawOwner, alive: ownerAlive } : null;
+		// `TransportOwnerLock.inspect()` throws on JSON parse / non-ENOENT I/O
+		// failures (see transport-owner-lock.ts `readOwner`). A corrupt
+		// `.transport.lock` file must not abort the whole status command —
+		// crash-recovery is its main use case and stale/damaged locks are
+		// exactly what it's there to surface.
+		let transportOwner: (TransportOwnerInfo & { alive: boolean }) | null = null;
+		let transportOwnerError: string | undefined;
+		try {
+			const ownerInspector = new TransportOwnerLock(dataDir, "tap:status");
+			const rawOwner = await ownerInspector.inspect();
+			if (rawOwner) {
+				transportOwner = { ...rawOwner, alive: isProcessAlive(rawOwner.pid) };
+			}
+		} catch (err) {
+			transportOwnerError = formatReadError(err);
+		}
 
 		const contactsRead = await readContacts(dataDir);
 		const journalRead = await readJournal(dataDir);
@@ -170,6 +182,7 @@ export async function statusCommand(flags: StatusFlags, opts: GlobalOptions): Pr
 				contacts: contactsRead.error,
 				journal: journalRead.error,
 				conversations: conversationsRead.error,
+				transportOwner: transportOwnerError,
 			},
 		});
 
@@ -299,7 +312,12 @@ async function readConversations(dataDir: string): Promise<ReadResult<Conversati
 		const filePath = join(conversationsDir, entry);
 		try {
 			const raw = await readFile(filePath, "utf-8");
-			value.push(JSON.parse(raw) as ConversationLog);
+			const parsed = JSON.parse(raw) as unknown;
+			if (!isConversationLog(parsed)) {
+				failed.push(entry);
+				continue;
+			}
+			value.push(parsed);
 		} catch {
 			failed.push(entry);
 		}
@@ -319,6 +337,18 @@ async function readConversations(dataDir: string): Promise<ReadResult<Conversati
 
 function formatReadError(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
+}
+
+function isConversationLog(value: unknown): value is ConversationLog {
+	// Minimal shape check — just enough so `summarizeMessages` can iterate
+	// safely. A file like `{}` or `{"messages": null}` is schema-invalid and
+	// must be counted as "unreadable" rather than crashing the whole command.
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as Record<string, unknown>;
+	if (!Array.isArray(record.messages)) return false;
+	if (typeof record.peerAgentId !== "number") return false;
+	if (typeof record.peerDisplayName !== "string") return false;
+	return true;
 }
 
 async function readHermesStatus(
@@ -350,18 +380,14 @@ async function readHermesStatus(
 		configError = formatReadError(err);
 	}
 
-	if (!config && !configError && !daemonState && !daemonStateError) {
-		// No config file, no broken config, no daemon state, no broken daemon
-		// state — genuinely not installed for this user.
-		return null;
-	}
-
 	const daemonRunning = daemonState ? isProcessAlive(daemonState.pid) : false;
 
 	if (!config) {
-		// We got here because configError OR a daemon state signal is present.
-		// Either way, treat Hermes as installed so the error/daemon warning
-		// paths still fire.
+		// `config` is only `null` when `loadTapHermesPluginConfig` threw, which
+		// means `configError` is set. The loader returns `{ identities: [] }`
+		// on ENOENT, never `null`, so there is no "no config at all" branch to
+		// worry about here. Treat this as installed-but-broken so the config
+		// error / daemon warnings still fire.
 		return {
 			installed: true,
 			daemon_running: daemonRunning,
@@ -517,12 +543,18 @@ function buildWarnings(input: {
 		contacts?: string;
 		journal?: string;
 		conversations?: string;
+		transportOwner?: string;
 	};
 }): string[] {
 	const warnings: string[] = [];
 
 	// Surface read failures first — if a store is unreadable, every other
 	// derived metric is silently zero and would mislead the operator.
+	if (input.readErrors.transportOwner) {
+		warnings.push(
+			`Failed to read .transport.lock: ${input.readErrors.transportOwner}. Transport owner state is unknown.`,
+		);
+	}
 	if (input.readErrors.contacts) {
 		warnings.push(
 			`Failed to read contacts.json: ${input.readErrors.contacts}. Contact counts are incomplete.`,

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -506,6 +506,54 @@ describe("tap status", () => {
 		).toBe(true);
 	});
 
+	it("surfaces a corrupt .transport.lock instead of aborting the command", async () => {
+		// Prior bug: an unguarded TransportOwnerLock.inspect() call meant a
+		// malformed lock file aborted the whole status command — which is
+		// exactly the crash-recovery scenario tap status exists to diagnose.
+		const dataDir = await makeAgentDir(tempRoot);
+		await writeFile(join(dataDir, ".transport.lock"), "{ not json", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.status).toBe("ok");
+		expect(output.data?.host.transport_owner).toBeNull();
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Failed to read .transport.lock") && w.includes("unknown"),
+			),
+		).toBe(true);
+	});
+
+	it("rejects schema-invalid conversation files instead of crashing summarizeMessages", async () => {
+		// Prior bug: readConversations accepted any parseable JSON as a
+		// ConversationLog, so `{}` or `{"messages": null}` made it to
+		// summarizeMessages which then threw on iteration.
+		const dataDir = await makeAgentDir(tempRoot);
+		await mkdir(join(dataDir, "conversations"), { recursive: true });
+		// Schema-invalid: missing messages array
+		await writeFile(join(dataDir, "conversations", "conv-empty.json"), "{}", "utf-8");
+		// Schema-invalid: messages is not an array
+		await writeFile(
+			join(dataDir, "conversations", "conv-null-messages.json"),
+			JSON.stringify({ messages: null, peerAgentId: 1, peerDisplayName: "X" }),
+			"utf-8",
+		);
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.status).toBe("ok");
+		expect(output.data?.messages.inbound_count).toBe(0);
+		expect(
+			output.data?.warnings.some(
+				(w) =>
+					w.includes("conversation file(s) unreadable") &&
+					(w.includes("conv-empty") || w.includes("conv-null-messages")),
+			),
+		).toBe(true);
+	});
+
 	it("surfaces corrupt individual conversation files as a warning", async () => {
 		// Prior bug: FileConversationLogger.listConversations silently skips
 		// files that fail to parse. That hid real corruption behind an

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -506,6 +506,67 @@ describe("tap status", () => {
 		).toBe(true);
 	});
 
+	it("surfaces corrupt individual conversation files as a warning", async () => {
+		// Prior bug: FileConversationLogger.listConversations silently skips
+		// files that fail to parse. That hid real corruption behind an
+		// undercount with no warning.
+		const dataDir = await makeAgentDir(tempRoot);
+
+		// Seed one valid conversation via the logger.
+		const logger = new FileConversationLogger(dataDir);
+		await logger.logMessage(
+			"conv-alice",
+			{
+				messageId: "in-1",
+				timestamp: "2026-04-14T10:00:00.000Z",
+				direction: "incoming",
+				scope: "general-chat",
+				content: "hi",
+				humanApprovalRequired: false,
+				humanApprovalGiven: null,
+			},
+			{ connectionId: "conn-1", peerAgentId: 100, peerDisplayName: "Alice" },
+		);
+		// Seed a corrupt file next to it.
+		await writeFile(join(dataDir, "conversations", "conv-broken.json"), "{ not json", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		// Good file still counted
+		expect(output.data?.messages.inbound_count).toBe(1);
+		// Bad file reported as warning
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("conversation file(s) unreadable") && w.includes("conv-broken"),
+			),
+		).toBe(true);
+	});
+
+	it("surfaces a corrupt Hermes daemon.json as a warning", async () => {
+		// Prior bug: readHermesStatus's unconditional catch around
+		// readHermesTapDaemonState coerced parse errors to null, so a broken
+		// daemon.json looked exactly like "daemon is not running".
+		const dataDir = await makeAgentDir(tempRoot);
+		// Install a valid hermes config so this data-dir is recognized as
+		// Hermes-managed, then write garbage in daemon.json.
+		await saveTapHermesPluginConfig(hermesHome, {
+			identities: [{ name: "default", dataDir, reconcileIntervalMinutes: 10 }],
+		});
+		const stateDir = join(hermesHome, "plugins", "trusted-agents-tap", "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(join(stateDir, "daemon.json"), "{ not json", "utf-8");
+
+		await statusCommand({ hermesHome }, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Hermes TAP daemon state file") && w.includes("cannot be parsed"),
+			),
+		).toBe(true);
+	});
+
 	it("surfaces a broken Hermes plugin config instead of reporting not-installed", async () => {
 		// Prior bug: readHermesStatus caught all errors from
 		// loadTapHermesPluginConfig and returned null, making "installed but

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -527,8 +527,9 @@ describe("tap status", () => {
 
 	it("rejects schema-invalid conversation files instead of crashing summarizeMessages", async () => {
 		// Prior bug: readConversations accepted any parseable JSON as a
-		// ConversationLog, so `{}` or `{"messages": null}` made it to
-		// summarizeMessages which then threw on iteration.
+		// ConversationLog, so `{}`, `{"messages": null}`, or
+		// `{"messages": [null]}` made it to summarizeMessages which then threw
+		// on iteration.
 		const dataDir = await makeAgentDir(tempRoot);
 		await mkdir(join(dataDir, "conversations"), { recursive: true });
 		// Schema-invalid: missing messages array
@@ -537,6 +538,22 @@ describe("tap status", () => {
 		await writeFile(
 			join(dataDir, "conversations", "conv-null-messages.json"),
 			JSON.stringify({ messages: null, peerAgentId: 1, peerDisplayName: "X" }),
+			"utf-8",
+		);
+		// Schema-invalid: messages contains non-object entries
+		await writeFile(
+			join(dataDir, "conversations", "conv-null-element.json"),
+			JSON.stringify({ messages: [null], peerAgentId: 1, peerDisplayName: "X" }),
+			"utf-8",
+		);
+		// Schema-invalid: message entry is missing direction
+		await writeFile(
+			join(dataDir, "conversations", "conv-bad-direction.json"),
+			JSON.stringify({
+				messages: [{ timestamp: "2026-01-01T00:00:00Z" }],
+				peerAgentId: 1,
+				peerDisplayName: "X",
+			}),
 			"utf-8",
 		);
 
@@ -549,9 +566,44 @@ describe("tap status", () => {
 			output.data?.warnings.some(
 				(w) =>
 					w.includes("conversation file(s) unreadable") &&
-					(w.includes("conv-empty") || w.includes("conv-null-messages")),
+					(w.includes("conv-empty") ||
+						w.includes("conv-null-messages") ||
+						w.includes("conv-null-element") ||
+						w.includes("conv-bad-direction")),
 			),
 		).toBe(true);
+	});
+
+	it("suppresses the queued-commands warning when the lock is unreadable", async () => {
+		// Prior bug: when .transport.lock was corrupt, transportOwner was null
+		// and transportIdle therefore true — so the queued-commands warning
+		// fired even though ownership was actually unknown. A live host might
+		// still be draining the queue.
+		const dataDir = await makeAgentDir(tempRoot);
+		await writeFile(join(dataDir, ".transport.lock"), "{ not json", "utf-8");
+		const journal = new FileRequestJournal(dataDir);
+		await journal.putOutbound({
+			requestId: "cmd-unknown",
+			requestKey: "outbound:command:cmd-unknown",
+			direction: "outbound",
+			kind: "request",
+			method: "command/connect",
+			peerAgentId: 0,
+			status: "queued",
+			metadata: { commandType: "connect", commandPayload: { inviteUrl: "tap://demo" } },
+		});
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		// The lock-read error warning MUST fire
+		expect(output.data?.warnings.some((w) => w.includes("Failed to read .transport.lock"))).toBe(
+			true,
+		);
+		// The queued-commands-idle warning MUST NOT fire — ownership is unknown
+		expect(
+			output.data?.warnings.some((w) => w.includes("queued command") && w.includes("draining")),
+		).toBe(false);
 	});
 
 	it("surfaces corrupt individual conversation files as a warning", async () => {

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -431,4 +431,100 @@ describe("tap status", () => {
 		expect(output.data?.journal.queued_commands).toBe(1);
 		expect(output.data?.warnings.some((w) => w.includes("queued command"))).toBe(true);
 	});
+
+	it("flags queued commands even when a stale (dead-pid) lock is present", async () => {
+		// Prior bug: the queued-commands warning was gated on
+		// `!input.transportOwner`, which is false when a stale lock file exists.
+		// In that state the operator only saw "stale lock" but not "nothing is
+		// draining your queue". Both matter because queued work is equally
+		// undrained in both cases.
+		const dataDir = await makeAgentDir(tempRoot);
+
+		// Write a lock file pointing at a pid that can't be alive.
+		const lockPath = join(dataDir, ".transport.lock");
+		await writeFile(
+			lockPath,
+			JSON.stringify({
+				pid: 999_999_999,
+				owner: "tap:listen",
+				acquiredAt: new Date().toISOString(),
+			}),
+			"utf-8",
+		);
+
+		const journal = new FileRequestJournal(dataDir);
+		await journal.putOutbound({
+			requestId: "cmd-stale",
+			requestKey: "outbound:command:cmd-stale",
+			direction: "outbound",
+			kind: "request",
+			method: "command/connect",
+			peerAgentId: 0,
+			status: "queued",
+			metadata: { commandType: "connect", commandPayload: { inviteUrl: "tap://demo" } },
+		});
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.transport_owner?.alive).toBe(false);
+		expect(output.data?.warnings.some((w) => w.includes("Stale transport lock"))).toBe(true);
+		expect(
+			output.data?.warnings.some((w) => w.includes("queued command") && w.includes("draining")),
+		).toBe(true);
+	});
+
+	it("surfaces corrupt request-journal.json as a warning instead of silent zero", async () => {
+		// A diagnosis command must never silently turn file corruption into
+		// "everything is fine". Prior bug: a catch-all in readJournal returned
+		// [] for JSON parse failures.
+		const dataDir = await makeAgentDir(tempRoot);
+		await writeFile(join(dataDir, "request-journal.json"), "{ not json", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.journal.inbound_pending).toBe(0);
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Failed to read request-journal.json") && w.includes("incomplete"),
+			),
+		).toBe(true);
+	});
+
+	it("surfaces corrupt contacts.json as a warning", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		await writeFile(join(dataDir, "contacts.json"), "[not an object", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Failed to read contacts.json") && w.includes("incomplete"),
+			),
+		).toBe(true);
+	});
+
+	it("surfaces a broken Hermes plugin config instead of reporting not-installed", async () => {
+		// Prior bug: readHermesStatus caught all errors from
+		// loadTapHermesPluginConfig and returned null, making "installed but
+		// config.json is garbage" indistinguishable from "Hermes is not
+		// installed". The whole point of the debug command is to expose the
+		// root cause.
+		const dataDir = await makeAgentDir(tempRoot);
+		const hermesPluginDir = join(hermesHome, "plugins", "trusted-agents-tap");
+		await mkdir(hermesPluginDir, { recursive: true });
+		await writeFile(join(hermesPluginDir, "config.json"), "{ not: json", "utf-8");
+
+		await statusCommand({ hermesHome }, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.hermes).not.toBeNull();
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Hermes TAP plugin config") && w.includes("cannot be parsed"),
+			),
+		).toBe(true);
+	});
 });

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,0 +1,434 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type Contact,
+	FileConversationLogger,
+	FileRequestJournal,
+	FileTrustStore,
+	TransportOwnerLock,
+} from "trusted-agents-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { statusCommand } from "../src/commands/status.js";
+import { saveTapHermesPluginConfig } from "../src/hermes/config.js";
+import { useCapturedOutput } from "./helpers/capture-output.js";
+
+const MINIMAL_CONFIG = [
+	"agent_id: 42",
+	"chain: eip155:8453",
+	"ows:",
+	"  wallet: demo-wallet",
+	"  api_key: demo-key",
+].join("\n");
+
+async function makeAgentDir(root: string, config = MINIMAL_CONFIG): Promise<string> {
+	const dataDir = join(root, "agent");
+	await mkdir(dataDir, { recursive: true });
+	await writeFile(join(dataDir, "config.yaml"), config, "utf-8");
+	return dataDir;
+}
+
+function makeContact(overrides: Partial<Contact> = {}): Contact {
+	return {
+		connectionId: "conn-1",
+		peerAgentId: 100,
+		peerChain: "eip155:8453",
+		peerOwnerAddress: "0x0000000000000000000000000000000000000000",
+		peerDisplayName: "Alice",
+		peerAgentAddress: "0x0000000000000000000000000000000000000000",
+		permissions: { transferGrants: [], schedulingGrants: [] },
+		establishedAt: new Date().toISOString(),
+		lastContactAt: new Date().toISOString(),
+		status: "active",
+		...overrides,
+	};
+}
+
+interface StatusResponse {
+	status: string;
+	data?: {
+		config: {
+			exists: boolean;
+			valid: boolean;
+			agent_id: number | null;
+			registered: boolean;
+		};
+		host: {
+			mode: string;
+			transport_owner: { owner: string; alive: boolean } | null;
+			hermes: {
+				daemon_running: boolean;
+				manages_this_data_dir: boolean;
+				configured_identities: string[];
+			} | null;
+		};
+		contacts: {
+			total: number;
+			active: number;
+			connecting: number;
+			oldest_connecting: { peer: string; age_minutes: number } | null;
+		};
+		messages: {
+			inbound_count: number;
+			outbound_count: number;
+			last_inbound: { peer: string; at: string } | null;
+			last_outbound: { peer: string; at: string } | null;
+		};
+		journal: {
+			inbound_pending: number;
+			outbound_pending: number;
+			queued_commands: number;
+			oldest_pending: { method: string; direction: string } | null;
+		};
+		warnings: string[];
+	};
+	error?: { code: string; message: string };
+}
+
+function readResponse(stdout: string[]): StatusResponse {
+	return JSON.parse(stdout.join("")) as StatusResponse;
+}
+
+describe("tap status", () => {
+	let tempRoot: string;
+	let hermesHome: string;
+	let originalHermesHome: string | undefined;
+	const { stdout: stdoutWrites, stderr: stderrWrites } = useCapturedOutput();
+
+	beforeEach(async () => {
+		tempRoot = await mkdtemp(join(tmpdir(), "tap-status-"));
+		hermesHome = join(tempRoot, "hermes-home");
+		await mkdir(hermesHome, { recursive: true });
+		originalHermesHome = process.env.HERMES_HOME;
+		process.env.HERMES_HOME = hermesHome;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		if (originalHermesHome === undefined) {
+			process.env.HERMES_HOME = undefined;
+		} else {
+			process.env.HERMES_HOME = originalHermesHome;
+		}
+		process.exitCode = undefined;
+		await rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("reports not-initialized when no config exists", async () => {
+		const dataDir = join(tempRoot, "empty-agent");
+		await mkdir(dataDir, { recursive: true });
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.status).toBe("ok");
+		expect(output.data?.host.mode).toBe("not-initialized");
+		expect(output.data?.config.exists).toBe(false);
+		expect(output.data?.warnings).toContain(
+			"No TAP config at this data dir. Run `tap init` to create one.",
+		);
+		expect(stderrWrites).toEqual([]);
+	});
+
+	it("reports not-registered when agent_id < 0", async () => {
+		const dataDir = await makeAgentDir(
+			tempRoot,
+			[
+				"agent_id: -1",
+				"chain: eip155:8453",
+				"ows:",
+				"  wallet: demo-wallet",
+				"  api_key: demo-key",
+			].join("\n"),
+		);
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("not-registered");
+		expect(output.data?.config.registered).toBe(false);
+		expect(output.data?.warnings.some((w) => w.includes("tap register"))).toBe(true);
+	});
+
+	it("reports idle when config is valid but nothing owns the transport", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("idle");
+		expect(output.data?.host.transport_owner).toBeNull();
+		expect(output.data?.config.registered).toBe(true);
+		expect(output.data?.config.agent_id).toBe(42);
+	});
+
+	it("detects cli-listener when tap:listen owns the transport", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		const lock = new TransportOwnerLock(dataDir, "tap:listen");
+		await lock.acquire();
+		try {
+			await statusCommand({}, { json: true, dataDir });
+		} finally {
+			await lock.release();
+		}
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("cli-listener");
+		expect(output.data?.host.transport_owner?.owner).toBe("tap:listen");
+		expect(output.data?.host.transport_owner?.alive).toBe(true);
+	});
+
+	it("detects hermes-managed mode and matches data dir", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		const lock = new TransportOwnerLock(dataDir, "hermes:default");
+		await lock.acquire();
+		await saveTapHermesPluginConfig(hermesHome, {
+			identities: [{ name: "default", dataDir, reconcileIntervalMinutes: 10 }],
+		});
+		try {
+			await statusCommand({ hermesHome }, { json: true, dataDir });
+		} finally {
+			await lock.release();
+		}
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("hermes-managed");
+		expect(output.data?.host.hermes?.manages_this_data_dir).toBe(true);
+		expect(output.data?.host.hermes?.configured_identities).toEqual(["default"]);
+	});
+
+	it("warns when Hermes is configured for a different data-dir but daemon is running", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		await saveTapHermesPluginConfig(hermesHome, {
+			identities: [
+				{ name: "other", dataDir: join(tempRoot, "other-agent"), reconcileIntervalMinutes: 10 },
+			],
+		});
+		// Simulate a live hermes daemon state file pointing at our PID (self,
+		// so isProcessAlive returns true).
+		const daemonStatePath = join(
+			hermesHome,
+			"plugins",
+			"trusted-agents-tap",
+			"state",
+			"daemon.json",
+		);
+		await mkdir(join(hermesHome, "plugins", "trusted-agents-tap", "state"), { recursive: true });
+		await writeFile(
+			daemonStatePath,
+			JSON.stringify({
+				pid: process.pid,
+				gatewayPid: process.pid,
+				socketPath: join(hermesHome, "tap-hermes.sock"),
+				startedAt: new Date().toISOString(),
+				identities: ["other"],
+			}),
+		);
+
+		await statusCommand({ hermesHome }, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.hermes?.daemon_running).toBe(true);
+		expect(output.data?.host.hermes?.manages_this_data_dir).toBe(false);
+		expect(output.data?.warnings.some((w) => w.includes("not in its configured identities"))).toBe(
+			true,
+		);
+	});
+
+	it("separates handshake state from message/send state", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		const store = new FileTrustStore(dataDir);
+		await store.addContact(makeContact({ peerAgentId: 100, peerDisplayName: "Alice" }));
+		await store.addContact(
+			makeContact({
+				connectionId: "conn-2",
+				peerAgentId: 200,
+				peerDisplayName: "Bob",
+				status: "connecting",
+				establishedAt: new Date(Date.now() - 15 * 60_000).toISOString(),
+			}),
+		);
+
+		const journal = new FileRequestJournal(dataDir);
+		await journal.putOutbound({
+			requestId: "conn-req-1",
+			requestKey: "outbound:conn-req-1",
+			direction: "outbound",
+			kind: "request",
+			method: "connection/request",
+			peerAgentId: 200,
+			status: "completed",
+		});
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		// Two contacts: one active, one stuck connecting — but zero actual messages.
+		expect(output.data?.contacts.total).toBe(2);
+		expect(output.data?.contacts.active).toBe(1);
+		expect(output.data?.contacts.connecting).toBe(1);
+		expect(output.data?.contacts.oldest_connecting?.peer).toContain("Bob");
+		expect(output.data?.messages.inbound_count).toBe(0);
+		expect(output.data?.messages.outbound_count).toBe(0);
+		expect(output.data?.messages.last_inbound).toBeNull();
+		expect(output.data?.warnings.some((w) => w.includes("Bob") && w.includes("connecting"))).toBe(
+			true,
+		);
+	});
+
+	it("counts inbound and outbound messages from the conversation log", async () => {
+		// Conversation logs are the canonical source because sendMessageInternal
+		// writes there but not to the request journal. Counting from the journal
+		// would silently miss every successful outbound `tap message send`.
+		const dataDir = await makeAgentDir(tempRoot);
+		const logger = new FileConversationLogger(dataDir);
+		const conversationId = "conv-alice";
+		const context = {
+			connectionId: "conn-1",
+			peerAgentId: 100,
+			peerDisplayName: "Alice",
+		};
+		await logger.logMessage(
+			conversationId,
+			{
+				messageId: "in-1",
+				timestamp: "2026-04-14T10:00:00.000Z",
+				direction: "incoming",
+				scope: "general-chat",
+				content: "hi",
+				humanApprovalRequired: false,
+				humanApprovalGiven: null,
+			},
+			context,
+		);
+		await logger.logMessage(
+			conversationId,
+			{
+				messageId: "in-2",
+				timestamp: "2026-04-14T10:05:00.000Z",
+				direction: "incoming",
+				scope: "general-chat",
+				content: "still here",
+				humanApprovalRequired: false,
+				humanApprovalGiven: null,
+			},
+			context,
+		);
+		await logger.logMessage(
+			conversationId,
+			{
+				messageId: "out-1",
+				timestamp: "2026-04-14T10:06:00.000Z",
+				direction: "outgoing",
+				scope: "general-chat",
+				content: "hello",
+				humanApprovalRequired: false,
+				humanApprovalGiven: null,
+			},
+			context,
+		);
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.messages.inbound_count).toBe(2);
+		expect(output.data?.messages.outbound_count).toBe(1);
+		expect(output.data?.messages.last_inbound?.peer).toContain("Alice");
+		expect(output.data?.messages.last_inbound?.at).toBe("2026-04-14T10:05:00.000Z");
+		expect(output.data?.messages.last_outbound?.peer).toContain("Alice");
+		expect(output.data?.messages.last_outbound?.at).toBe("2026-04-14T10:06:00.000Z");
+	});
+
+	it("reports config-invalid when config.yaml is empty", async () => {
+		const dataDir = join(tempRoot, "broken-agent");
+		await mkdir(dataDir, { recursive: true });
+		await writeFile(join(dataDir, "config.yaml"), "", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("config-invalid");
+		expect(output.data?.config.exists).toBe(true);
+		expect(output.data?.config.valid).toBe(false);
+		expect(output.data?.config.registered).toBe(false);
+		expect(output.data?.warnings.some((w) => w.includes("cannot be parsed"))).toBe(true);
+		// Must not fall into the `tap register` remediation path.
+		expect(output.data?.warnings.some((w) => w.includes("tap register"))).toBe(false);
+	});
+
+	it("reports config-invalid when config.yaml has garbage yaml", async () => {
+		const dataDir = join(tempRoot, "broken-yaml-agent");
+		await mkdir(dataDir, { recursive: true });
+		await writeFile(join(dataDir, "config.yaml"), "not: [valid: yaml", "utf-8");
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("config-invalid");
+		expect(output.data?.config.valid).toBe(false);
+		expect(output.data?.warnings.some((w) => w.includes("cannot be parsed"))).toBe(true);
+	});
+
+	it("reports not-registered when agent_id key is missing from config.yaml", async () => {
+		// This is the real trap the loader creates: yaml without agent_id was
+		// previously defaulted to 0 and reported as registered=true. Guard
+		// against regression.
+		const dataDir = await makeAgentDir(
+			tempRoot,
+			["chain: eip155:8453", "ows:", "  wallet: demo-wallet", "  api_key: demo-key"].join("\n"),
+		);
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.host.mode).toBe("not-registered");
+		expect(output.data?.config.valid).toBe(true);
+		expect(output.data?.config.agent_id).toBeNull();
+		expect(output.data?.config.registered).toBe(false);
+	});
+
+	it("rejects --config pointing outside the selected data dir", async () => {
+		const dataDirA = await makeAgentDir(tempRoot);
+		// Move foreign config into a directory separate from dataDirA so the
+		// paths genuinely mismatch. `validateConfigPathInDataDir` only fires
+		// when both --data-dir and --config are set and point at different
+		// parents.
+		const foreignParent = join(tempRoot, "agent-b");
+		await mkdir(foreignParent, { recursive: true });
+		const foreignConfig = join(foreignParent, "config.yaml");
+		await writeFile(
+			foreignConfig,
+			["agent_id: 7", "chain: eip155:8453", "ows:", "  wallet: other", "  api_key: other"].join(
+				"\n",
+			),
+			"utf-8",
+		);
+
+		await statusCommand({}, { json: true, dataDir: dataDirA, config: foreignConfig });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.status).toBe("error");
+		expect(output.error?.message).toContain("Config path must match the TAP data dir");
+	});
+
+	it("flags queued commands with no transport owner", async () => {
+		const dataDir = await makeAgentDir(tempRoot);
+		const journal = new FileRequestJournal(dataDir);
+		await journal.putOutbound({
+			requestId: "cmd-1",
+			requestKey: "outbound:command:cmd-1",
+			direction: "outbound",
+			kind: "request",
+			method: "command/connect",
+			peerAgentId: 0,
+			status: "queued",
+			metadata: { commandType: "connect", commandPayload: { inviteUrl: "tap://demo" } },
+		});
+
+		await statusCommand({}, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		expect(output.data?.journal.queued_commands).toBe(1);
+		expect(output.data?.warnings.some((w) => w.includes("queued command"))).toBe(true);
+	});
+});

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -106,7 +106,11 @@ describe("tap status", () => {
 
 	afterEach(async () => {
 		if (originalHermesHome === undefined) {
-			process.env.HERMES_HOME = undefined;
+			// `process.env.FOO = undefined` coerces to the string "undefined"
+			// in Node; we must `delete` the key to actually unset it and not
+			// leak a bogus HERMES_HOME into later suites.
+			// biome-ignore lint/performance/noDelete: process.env requires delete to unset
+			delete process.env.HERMES_HOME;
 		} else {
 			process.env.HERMES_HOME = originalHermesHome;
 		}
@@ -518,6 +522,10 @@ describe("tap status", () => {
 		const output = readResponse(stdoutWrites);
 		expect(output.status).toBe("ok");
 		expect(output.data?.host.transport_owner).toBeNull();
+		// Mode must be `transport-unknown`, not `idle` — ownership is explicitly
+		// unknown when the lock is unreadable, and JSON consumers that key off
+		// `mode` alone must not be misled into thinking the data dir is idle.
+		expect(output.data?.host.mode).toBe("transport-unknown");
 		expect(
 			output.data?.warnings.some(
 				(w) => w.includes("Failed to read .transport.lock") && w.includes("unknown"),

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -643,6 +643,77 @@ describe("tap status", () => {
 		).toBe(true);
 	});
 
+	it("suppresses identity-mismatch warning when hermes config is unreadable", async () => {
+		// Prior bug: when config.json is malformed, readHermesStatus forces
+		// manages_this_data_dir=false (can't read identities), then downstream
+		// the "daemon is running but this data-dir is not in configured
+		// identities" warning fires — even though the actual problem is the
+		// unreadable config, not a missing identity.
+		const dataDir = await makeAgentDir(tempRoot);
+		const hermesPluginDir = join(hermesHome, "plugins", "trusted-agents-tap");
+		await mkdir(hermesPluginDir, { recursive: true });
+		await writeFile(join(hermesPluginDir, "config.json"), "{ not: json", "utf-8");
+
+		// And a live daemon state pointing at our pid so daemon_running is true.
+		const stateDir = join(hermesPluginDir, "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(
+			join(stateDir, "daemon.json"),
+			JSON.stringify({
+				pid: process.pid,
+				gatewayPid: process.pid,
+				socketPath: join(hermesHome, "tap-hermes.sock"),
+				startedAt: new Date().toISOString(),
+				identities: [],
+			}),
+		);
+
+		await statusCommand({ hermesHome }, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		// Config-error warning MUST fire (the real problem)
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Hermes TAP plugin config") && w.includes("cannot be parsed"),
+			),
+		).toBe(true);
+		// Contradictory "not in configured identities" warning MUST NOT fire
+		expect(output.data?.warnings.some((w) => w.includes("not in its configured identities"))).toBe(
+			false,
+		);
+	});
+
+	it("suppresses daemon-not-running warning when daemon.json is unreadable", async () => {
+		// Prior bug: when daemon.json is malformed, daemon_running defaults to
+		// false; the "TAP daemon is not running" warning then fires even though
+		// the daemon may actually be running — contradicting the
+		// daemon-state-error warning that correctly says "running state is
+		// unknown".
+		const dataDir = await makeAgentDir(tempRoot);
+		await saveTapHermesPluginConfig(hermesHome, {
+			identities: [{ name: "default", dataDir, reconcileIntervalMinutes: 10 }],
+		});
+		const stateDir = join(hermesHome, "plugins", "trusted-agents-tap", "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(join(stateDir, "daemon.json"), "{ not json", "utf-8");
+
+		await statusCommand({ hermesHome }, { json: true, dataDir });
+
+		const output = readResponse(stdoutWrites);
+		// Daemon-state-error warning MUST fire
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("Hermes TAP daemon state file") && w.includes("cannot be parsed"),
+			),
+		).toBe(true);
+		// Contradictory "daemon is not running" warning MUST NOT fire
+		expect(
+			output.data?.warnings.some(
+				(w) => w.includes("TAP daemon is not running") || w.includes("Start or restart"),
+			),
+		).toBe(false);
+	});
+
 	it("surfaces a corrupt Hermes daemon.json as a warning", async () => {
 		// Prior bug: readHermesStatus's unconditional catch around
 		// readHermesTapDaemonState coerced parse errors to null, so a broken

--- a/skills/trusted-agents/SKILL.md
+++ b/skills/trusted-agents/SKILL.md
@@ -28,7 +28,17 @@ JSON envelope shape: `{ "status": "ok"|"error", "data": ..., "metadata": { "form
 
 ## Status Check
 
-Run these to figure out where things stand (piped output is JSON by default, `--output json` is optional):
+Start with `tap status` — it is the host-aware first-step debug command and answers most questions without running any other command:
+
+```
+tap status   → Reports mode (idle / cli-listener / hermes-managed / openclaw-managed),
+               transport owner, contact counts (handshake state), message/send
+               counts (actual peer communication), journal pending work, warnings.
+```
+
+`tap status` distinguishes "contact is active" (handshake complete) from "a real message has arrived" (message/send counted in journal). Use it first when a connection looked successful but you're unsure whether any actual messages flowed.
+
+Drill-down commands if `tap status` points to a specific problem:
 
 ```
 which tap                                          → Not found? See Install
@@ -37,6 +47,8 @@ tap config show --select agent_id,chain            → Errors? Start at Onboard 
 tap identity show --select agent_id,chain          → agent_id < 0? Resume Onboard (fund + register)
 tap balance                                        → Check funding
 tap contacts list --select name,status             → Empty? See Connect
+tap journal list --status pending                  → Stuck pending? See Recovery
+tap conversations list                             → Inspect per-peer transcripts
 ```
 
 If you're inside **OpenClaw Gateway** or **Hermes** and `tap_gateway` is available, also check:
@@ -628,6 +640,8 @@ tap app remove @trustedagents/app-scheduling
 Transfer, scheduling, and permission-request handling are built into the TAP runtime today. `tap app install` is for additional third-party TAP apps published to npm.
 
 ## Debugging
+
+Start with `tap status` for a host-aware overview (runtime mode, transport owner, contacts vs messages, journal pending work). It answers "is my host even running?" and "did any real message/send ever arrive?" without starting any transport.
 
 The request journal is the single source of truth for in-flight and recently completed protocol operations. Use these read-only commands to inspect it when a connection or message seems stuck:
 


### PR DESCRIPTION
## Summary
- New top-level `tap status` command that reports runtime state for a TAP data dir without starting any transport. Pure filesystem reads: transport owner lock, contacts, conversation logs, request journal, and the Hermes daemon state file.
- Separates handshake state (contacts) from message state (conversations) so "active contact with zero real messages" is immediately obvious — which was the exact confusion behind the recent Hermes debugging report.
- Detects host mode from the transport owner lock label (`hermes:*`, `openclaw:*`, `tap:listen`, other `tap:*`) and cross-references Hermes's configured identities, flagging the common multi-runtime pitfalls (stale lock, stuck `connecting` contact, queued commands with no owner, Hermes daemon running but not managing this data dir).

## Why
Today there is no single host-aware debug command. `tap hermes status` only covers Hermes, and everything else is spread across `tap contacts list`, `tap journal list`, `tap conversations list`, and the `.transport.lock` file. A reporter recently hit this while debugging a connection that succeeded at the handshake layer but showed no messages, and had no single place to confirm "did any real peer traffic happen vs just the handshake?". `tap status` answers that in one output.

## Key design calls
- **Filesystem-only.** No `createCliRuntime`, no transport start. The command has to work when the runtime is unhealthy — that's when you need it.
- **Config parsing is direct.** Uses `YAML.parse` against `config.yaml` rather than `loadTrustedAgentConfigFromDataDir`, because the loader defaults a missing `agent_id` to `0` which would misreport unregistered agents as `registered: true`. The command returns a discriminated `missing | invalid | parsed` state and has a dedicated `config-invalid` host mode with a distinct remediation ("fix or re-run `tap init`" instead of "run `tap register`").
- **Message counts come from the conversation logger.** `TapMessagingService.sendMessageInternal` writes to conversations but does NOT journal outbound `message/send` rows, so counting from the journal silently drops every successful outbound send. The conversation log is the source of truth.
- **Rejects `--config` outside `--data-dir`.** Same guard every other command runs via `loadConfig()` — prevents an internally-inconsistent status that reads contacts from agent A but reports `agent_id` from agent B.

## Test plan
- [x] 13 unit tests in `packages/cli/test/status.test.ts` covering: not-initialized, not-registered, idle, cli-listener, hermes-managed, Hermes misconfigured-for-this-data-dir, queued-commands-without-owner, handshake-vs-message separation, conversation-log-based counting, `config-invalid` from empty/garbage yaml, missing-agent_id-key, and `--config` path rejection.
- [x] Full workspace typecheck ✓
- [x] `bun run lint` ✓
- [x] Full CLI test suite (290/291 — one pre-existing `migrate-wallet` flake unrelated to these changes)
- [x] Smoke tested the built binary for text output, JSON output, `config-invalid` path, and cross-data-dir `--config` rejection

## Reviewer notes
- Does NOT update the `packages/cli/assets/skills/trusted-agents/SKILL.md` mirror even though `skills/trusted-agents/SKILL.md` changes. The mirror is already 134 lines out of sync with the canonical at `main`, so regenerating it in this PR would conflate the `tap status` docs update with unrelated pre-existing drift. The mirror catches up whenever someone runs `bun run --cwd packages/cli build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces a new command that reads/parses multiple on-disk state files (locks, journals, conversation logs, Hermes state) and adds new warning/mode logic that could misreport state if edge cases are missed, though it is read-only and transport-free.
> 
> **Overview**
> Adds a new top-level `tap status` command that produces a host-aware, **filesystem-only** runtime snapshot for the selected TAP data dir (config validity/registration, transport lock owner + liveness, contact handshake state, conversation-based message counts, and request-journal pending/queued work).
> 
> Implements robust error-tolerant readers in `commands/status.ts` that *surface corruption as warnings* (e.g., unreadable `.transport.lock`, `contacts.json`, `request-journal.json`, or individual conversation files) and classifies host mode (`idle`, `cli-listener`, `hermes-managed`, `openclaw-managed`, `transport-unknown`, etc.), including Hermes identity/daemon cross-check warnings.
> 
> Adds a comprehensive `status.test.ts` suite covering mode detection, handshake-vs-message separation, queued-command/stale-lock scenarios, config edge cases (missing/empty/invalid YAML, missing `agent_id`), Hermes misconfiguration, and corruption handling, and updates `skills/trusted-agents/SKILL.md` to document `tap status` as the recommended first debug step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb245d3da3a232a66b020b9f6abef635fbcd7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->