### PR TITLE
fix(transport): close XMTP startup handles

### DIFF
--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -71,6 +71,11 @@ export class XmtpTransport implements TransportProvider {
 	private readonly processedIncomingRequests = new Map<string, number>();
 	private running = false;
 	private streamCloser?: { return?: () => Promise<unknown> };
+	private listenerPromise?: Promise<void>;
+	private reconnectCanceler?: {
+		timer: ReturnType<typeof setTimeout>;
+		resolve: () => void;
+	};
 	private readonly inboxIdToAddress = new Map<string, `0x${string}`>();
 	private readonly agentResolver?: IAgentResolver;
 	private readonly resolveCacheTtlMs: number;
@@ -329,10 +334,26 @@ export class XmtpTransport implements TransportProvider {
 		const stream = this.streamCloser;
 		this.streamCloser = undefined;
 
+		if (this.reconnectCanceler) {
+			clearTimeout(this.reconnectCanceler.timer);
+			this.reconnectCanceler.resolve();
+			this.reconnectCanceler = undefined;
+		}
+
 		try {
 			await stream?.return?.();
 		} catch {
 			// Ignore stream close errors
+		}
+
+		const listener = this.listenerPromise;
+		this.listenerPromise = undefined;
+		if (listener) {
+			try {
+				await listener;
+			} catch {
+				// Listener errors are already swallowed inside the reconnect loop
+			}
 		}
 
 		for (const pending of this.pendingRequests.values()) {
@@ -357,7 +378,7 @@ export class XmtpTransport implements TransportProvider {
 	}
 
 	private listenWithReconnect(): void {
-		(async () => {
+		this.listenerPromise = (async () => {
 			while (this.running) {
 				try {
 					await this.listenForMessages();
@@ -365,7 +386,13 @@ export class XmtpTransport implements TransportProvider {
 					// Stream failed — will retry after delay
 				}
 				if (this.running) {
-					await new Promise((resolve) => setTimeout(resolve, RECONNECT_DELAY_MS));
+					await new Promise<void>((resolve) => {
+						const timer = setTimeout(() => {
+							this.reconnectCanceler = undefined;
+							resolve();
+						}, RECONNECT_DELAY_MS);
+						this.reconnectCanceler = { timer, resolve };
+					});
 				}
 			}
 		})();

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -72,6 +72,7 @@ export class XmtpTransport implements TransportProvider {
 	private running = false;
 	private streamCloser?: { return?: () => Promise<unknown> };
 	private listenerPromise?: Promise<void>;
+	private streamOpenAbort?: () => void;
 	private reconnectCanceler?: {
 		timer: ReturnType<typeof setTimeout>;
 		resolve: () => void;
@@ -340,6 +341,11 @@ export class XmtpTransport implements TransportProvider {
 			this.reconnectCanceler = undefined;
 		}
 
+		if (this.streamOpenAbort) {
+			this.streamOpenAbort();
+			this.streamOpenAbort = undefined;
+		}
+
 		try {
 			await stream?.return?.();
 		} catch {
@@ -411,9 +417,26 @@ export class XmtpTransport implements TransportProvider {
 	private async listenForMessages(): Promise<void> {
 		if (!this.client) return;
 
-		const stream = await this.client.conversations.streamAllDmMessages({
+		// The SDK call can stall (network/handshake), so race it against a
+		// stop-initiated abort signal. Without this race, `await transport.stop()`
+		// would block on `listenerPromise` indefinitely when the stream never
+		// opens — exactly the one-shot CLI flow this change is meant to unblock.
+		const streamPromise = this.client.conversations.streamAllDmMessages({
 			disableSync: true,
 		});
+		const aborted: Promise<null> = new Promise((resolve) => {
+			this.streamOpenAbort = () => resolve(null);
+		});
+		const stream = await Promise.race([streamPromise, aborted]);
+		this.streamOpenAbort = undefined;
+
+		if (stream === null) {
+			// Stop was signaled before the stream opened. Close any stream that
+			// lands later so we don't leak an open handle.
+			streamPromise.then((s) => s.return?.()).catch(() => {});
+			return;
+		}
+
 		this.streamCloser = stream;
 		if (!this.running) {
 			if (this.streamCloser === stream) {

--- a/packages/core/src/transport/xmtp.ts
+++ b/packages/core/src/transport/xmtp.ts
@@ -70,7 +70,7 @@ export class XmtpTransport implements TransportProvider {
 	private readonly pendingRequests = new Map<string, PendingRequest>();
 	private readonly processedIncomingRequests = new Map<string, number>();
 	private running = false;
-	private streamCloser?: { return?: (value?: unknown) => Promise<unknown> };
+	private streamCloser?: { return?: () => Promise<unknown> };
 	private readonly inboxIdToAddress = new Map<string, `0x${string}`>();
 	private readonly agentResolver?: IAgentResolver;
 	private readonly resolveCacheTtlMs: number;
@@ -117,16 +117,24 @@ export class XmtpTransport implements TransportProvider {
 				? { dbPath: (inboxId: string) => `${this.config.dbPath}/${inboxId}.db3` }
 				: {}),
 		};
-		const createClient = () =>
-			Promise.race([
-				Client.create(signer, clientOptions),
-				new Promise<never>((_, reject) => {
-					setTimeout(
-						() => reject(new TransportError("XMTP Client.create() timed out")),
-						CLIENT_CREATE_TIMEOUT_MS,
-					);
-				}),
-			]);
+		const createClient = async () => {
+			let timeout: ReturnType<typeof setTimeout> | undefined;
+			try {
+				return await Promise.race([
+					Client.create(signer, clientOptions),
+					new Promise<never>((_, reject) => {
+						timeout = setTimeout(
+							() => reject(new TransportError("XMTP Client.create() timed out")),
+							CLIENT_CREATE_TIMEOUT_MS,
+						);
+					}),
+				]);
+			} finally {
+				if (timeout) {
+					clearTimeout(timeout);
+				}
+			}
+		};
 
 		try {
 			this.client = await createClient();
@@ -318,9 +326,11 @@ export class XmtpTransport implements TransportProvider {
 		}
 
 		this.running = false;
+		const stream = this.streamCloser;
+		this.streamCloser = undefined;
 
 		try {
-			await this.streamCloser?.return?.(undefined);
+			await stream?.return?.();
 		} catch {
 			// Ignore stream close errors
 		}
@@ -378,14 +388,27 @@ export class XmtpTransport implements TransportProvider {
 			disableSync: true,
 		});
 		this.streamCloser = stream;
+		if (!this.running) {
+			if (this.streamCloser === stream) {
+				this.streamCloser = undefined;
+			}
+			await stream.return?.();
+			return;
+		}
 
-		for await (const message of stream) {
-			if (!this.running) break;
-			try {
-				await this.processMessage(this.toIncomingMessage(message));
-				await this.advanceCheckpoint(message.conversationId, message.sentAtNs, message.id);
-			} catch {
-				// Leave the checkpoint unchanged so transient failures can be retried.
+		try {
+			for await (const message of stream) {
+				if (!this.running) break;
+				try {
+					await this.processMessage(this.toIncomingMessage(message));
+					await this.advanceCheckpoint(message.conversationId, message.sentAtNs, message.id);
+				} catch {
+					// Leave the checkpoint unchanged so transient failures can be retried.
+				}
+			}
+		} finally {
+			if (this.streamCloser === stream) {
+				this.streamCloser = undefined;
 			}
 		}
 	}

--- a/packages/core/test/unit/transport/xmtp.test.ts
+++ b/packages/core/test/unit/transport/xmtp.test.ts
@@ -395,6 +395,31 @@ describe("XmtpTransport", () => {
 				vi.useRealTimers();
 			}
 		});
+
+		it("clears the client creation timeout when Client.create rejects", async () => {
+			vi.useFakeTimers();
+			const createSpy = vi
+				.spyOn(Client, "create")
+				.mockRejectedValue(new Error("client create failure"));
+			const failingTransport = new XmtpTransport(
+				{
+					...TEST_CONFIG,
+					dbPath: join(dir.path, "xmtp-start-fail"),
+					dbEncryptionKey: "0x0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				trustStore,
+			);
+
+			try {
+				await expect(failingTransport.start()).rejects.toThrow("client create failure");
+
+				expect(createSpy).toHaveBeenCalledTimes(1);
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				createSpy.mockRestore();
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe("send", () => {
@@ -1385,11 +1410,34 @@ describe("XmtpTransport", () => {
 
 			internals(transport).listenWithReconnect();
 			await sleep(10);
-			await transport.stop();
+			const stopPromise = transport.stop();
 			streamReady.resolve(stream);
+			await stopPromise;
 
-			await vi.waitFor(() => expect(streamReturn).toHaveBeenCalledTimes(1));
+			expect(streamReturn).toHaveBeenCalledTimes(1);
 			expect(streamNext).not.toHaveBeenCalled();
+		});
+
+		it("cancels the reconnect sleep when stop runs during the retry delay", async () => {
+			mockSetup.client.conversations.streamAllDmMessages.mockRejectedValueOnce(
+				new Error("transient stream failure"),
+			);
+			injectMockClient();
+
+			internals(transport).listenWithReconnect();
+
+			await vi.waitFor(() => {
+				expect(internals(transport).reconnectCanceler).toBeDefined();
+			});
+
+			const stopStart = Date.now();
+			await transport.stop();
+			const stopElapsedMs = Date.now() - stopStart;
+
+			// Without a cancellable sleep this would block for RECONNECT_DELAY_MS (5_000ms).
+			expect(stopElapsedMs).toBeLessThan(1_000);
+			expect(internals(transport).reconnectCanceler).toBeUndefined();
+			expect(internals(transport).listenerPromise).toBeUndefined();
 		});
 
 		it("processes streamed messages sequentially before advancing to the next one", async () => {

--- a/packages/core/test/unit/transport/xmtp.test.ts
+++ b/packages/core/test/unit/transport/xmtp.test.ts
@@ -1418,6 +1418,35 @@ describe("XmtpTransport", () => {
 			expect(streamNext).not.toHaveBeenCalled();
 		});
 
+		it("does not block stop when streamAllDmMessages never resolves", async () => {
+			const hangingStreamOpen = createDeferred<never>();
+			const streamOpenSpy = vi.fn(async () => {
+				await hangingStreamOpen.promise;
+				throw new Error("unreachable");
+			});
+			mockSetup.client.conversations.streamAllDmMessages.mockImplementationOnce(
+				streamOpenSpy as unknown as typeof mockSetup.client.conversations.streamAllDmMessages,
+			);
+			injectMockClient();
+
+			internals(transport).listenWithReconnect();
+
+			await vi.waitFor(() => {
+				expect(streamOpenSpy).toHaveBeenCalled();
+				expect(internals(transport).streamOpenAbort).toBeDefined();
+			});
+
+			const stopStart = Date.now();
+			await transport.stop();
+			const stopElapsedMs = Date.now() - stopStart;
+
+			// Without the abort race, stop() would hang on the pending listener promise.
+			expect(stopElapsedMs).toBeLessThan(500);
+			expect(internals(transport).streamOpenAbort).toBeUndefined();
+			expect(internals(transport).listenerPromise).toBeUndefined();
+			expect(internals(transport).client).toBeNull();
+		});
+
 		it("cancels the reconnect sleep when stop runs during the retry delay", async () => {
 			mockSetup.client.conversations.streamAllDmMessages.mockRejectedValueOnce(
 				new Error("transient stream failure"),

--- a/packages/core/test/unit/transport/xmtp.test.ts
+++ b/packages/core/test/unit/transport/xmtp.test.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { Client } from "@xmtp/node-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionError } from "../../../src/common/errors.js";
 import { createEmptyPermissionState } from "../../../src/permissions/types.js";
@@ -365,6 +366,34 @@ describe("XmtpTransport", () => {
 
 		it("should return false for isReachable before start", async () => {
 			expect(await transport.isReachable(42)).toBe(false);
+		});
+
+		it("clears the client creation timeout after start succeeds", async () => {
+			vi.useFakeTimers();
+			const createSpy = vi
+				.spyOn(Client, "create")
+				.mockResolvedValue(
+					mockSetup.client as unknown as Awaited<ReturnType<typeof Client.create>>,
+				);
+			const startedTransport = new XmtpTransport(
+				{
+					...TEST_CONFIG,
+					dbPath: join(dir.path, "xmtp-start"),
+					dbEncryptionKey: "0x0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				trustStore,
+			);
+
+			try {
+				await startedTransport.start();
+
+				expect(createSpy).toHaveBeenCalledTimes(1);
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				await startedTransport.stop();
+				createSpy.mockRestore();
+				vi.useRealTimers();
+			}
 		});
 	});
 
@@ -1332,6 +1361,35 @@ describe("XmtpTransport", () => {
 			await listenPromise;
 
 			expect(mockSetup.streamOptions).toEqual([{ disableSync: true }]);
+		});
+
+		it("closes the DM stream if stop occurs while the stream is opening", async () => {
+			const streamReady = createDeferred<{
+				[Symbol.asyncIterator](): AsyncIterator<MockMessage>;
+				next(): Promise<IteratorResult<MockMessage>>;
+				return(): Promise<IteratorResult<MockMessage>>;
+			}>();
+			const streamReturn = vi.fn(async () => ({ value: undefined, done: true as const }));
+			const streamNext = vi.fn(() => new Promise<IteratorResult<MockMessage>>(() => {}));
+			const stream = {
+				[Symbol.asyncIterator]() {
+					return this;
+				},
+				next: streamNext,
+				return: streamReturn,
+			};
+			mockSetup.client.conversations.streamAllDmMessages.mockImplementationOnce(
+				async () => await streamReady.promise,
+			);
+			injectMockClient();
+
+			internals(transport).listenWithReconnect();
+			await sleep(10);
+			await transport.stop();
+			streamReady.resolve(stream);
+
+			await vi.waitFor(() => expect(streamReturn).toHaveBeenCalledTimes(1));
+			expect(streamNext).not.toHaveBeenCalled();
 		});
 
 		it("processes streamed messages sequentially before advancing to the next one", async () => {


### PR DESCRIPTION
XMTP-backed one-shot commands could print a successful result and then keep Node alive. The transport had two shutdown leaks: the `Client.create()` timeout stayed ref'd after a successful client startup, and a DM stream that resolved after `stop()` could enter its async iterator with no remaining shutdown handle. This clears the startup timeout and closes any stream that appears after shutdown, with regression coverage for both cases.

Validated with `bun run lint`, `bun run --cwd packages/core typecheck`, `bun run --cwd packages/core build`, `bun run vitest run packages/core/test/unit/transport/xmtp.test.ts`, `bun run vitest run packages/cli/test/e2e/e2e-mock.test.ts`, and a live XMTP transport start/stop smoke under an external timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches XMTP transport lifecycle/concurrency around streaming and shutdown; mistakes could cause hangs, leaked handles, or missed message processing during stop/reconnect.
> 
> **Overview**
> Fixes XMTP transport shutdown leaks that could keep Node alive after one-shot commands complete.
> 
> `Client.create()` startup timeout is now always cleared (success or failure), and the DM listener loop is made stoppable by **aborting a hanging stream-open**, **cancelling reconnect backoff sleeps**, and **ensuring any stream that resolves after `stop()` is immediately closed**. Adds unit tests covering timeout cleanup and the new stop semantics during stream-open and reconnect delays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f420ca314333249b4896e95aac512913e753c4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->