### PR TITLE
feat(expenses): add shared expense ledger MVP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,16 @@
         "vitest": "^3.0.0",
       },
     },
+    "packages/app-expenses": {
+      "name": "@trustedagents/app-expenses",
+      "version": "0.1.0",
+      "dependencies": {
+        "trusted-agents-core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
+      },
+    },
     "packages/app-scheduling": {
       "name": "@trustedagents/app-scheduling",
       "version": "0.1.0",
@@ -35,6 +45,7 @@
       },
       "dependencies": {
         "@open-wallet-standard/core": "npm:@silicon-intern/ows-core@^1.2.0-eip712.3",
+        "@trustedagents/app-expenses": "workspace:*",
         "@x402/evm": "^2.5.0",
         "@x402/fetch": "^2.5.0",
         "commander": "^13.0.0",
@@ -65,6 +76,21 @@
         "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^25.3.3",
         "@types/uuid": "^10.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
+    "packages/expense-server": {
+      "name": "trusted-agents-expense-server",
+      "version": "0.1.0",
+      "bin": {
+        "tap-expense-server": "./dist/bin.js",
+      },
+      "dependencies": {
+        "@trustedagents/app-expenses": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0",
       },
@@ -936,6 +962,8 @@
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@trustedagents/app-expenses": ["@trustedagents/app-expenses@workspace:packages/app-expenses"],
 
     "@trustedagents/app-scheduling": ["@trustedagents/app-scheduling@workspace:packages/app-scheduling"],
 
@@ -2060,6 +2088,8 @@
     "trusted-agents-cli": ["trusted-agents-cli@workspace:packages/cli"],
 
     "trusted-agents-core": ["trusted-agents-core@workspace:packages/core"],
+
+    "trusted-agents-expense-server": ["trusted-agents-expense-server@workspace:packages/expense-server"],
 
     "trusted-agents-sdk": ["trusted-agents-sdk@workspace:packages/sdk"],
 

--- a/docs/superpowers/plans/2026-04-23-shared-expense-ledger-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-shared-expense-ledger-implementation.md
@@ -1,0 +1,77 @@
+# Shared Expense Ledger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first useful shared expense loop: log an off-chain expense, compute a shared USDC balance, create a net settlement intent, and expose it through the TAP CLI.
+
+**Architecture:** Add a TAP expense app package for shared types, validation, split math, and grant matching. Add a small centralized expense server package with repository boundaries and a Node HTTP API. Add CLI commands that configure the server URL, resolve TAP contacts, post expenses, inspect balances/history, and create settlement intents; actual USDC execution remains agent-owned.
+
+**Tech Stack:** TypeScript, Bun workspaces, Vitest, Node HTTP, existing TAP config/trust store helpers, existing CLI output envelope.
+
+---
+
+### Task 1: Expense App Primitives
+
+**Files:**
+- Create: `packages/app-expenses/package.json`
+- Create: `packages/app-expenses/tsconfig.json`
+- Create: `packages/app-expenses/src/types.ts`
+- Create: `packages/app-expenses/src/amounts.ts`
+- Create: `packages/app-expenses/src/grants.ts`
+- Create: `packages/app-expenses/src/index.ts`
+- Test: `packages/app-expenses/test/amounts.test.ts`
+- Test: `packages/app-expenses/test/grants.test.ts`
+
+- [x] **Step 1: Write failing amount and grant tests**
+- [x] **Step 2: Run tests and verify they fail because the package does not exist**
+- [x] **Step 3: Implement expense types, USDC minor-unit parsing, equal splits, group id derivation, and `expense/settle` grant matching**
+- [x] **Step 4: Run package tests and verify they pass**
+
+### Task 2: Expense Server Core
+
+**Files:**
+- Create: `packages/expense-server/package.json`
+- Create: `packages/expense-server/tsconfig.json`
+- Create: `packages/expense-server/src/types.ts`
+- Create: `packages/expense-server/src/store.ts`
+- Create: `packages/expense-server/src/ledger.ts`
+- Create: `packages/expense-server/src/http.ts`
+- Create: `packages/expense-server/src/bin.ts`
+- Create: `packages/expense-server/src/index.ts`
+- Test: `packages/expense-server/test/ledger.test.ts`
+- Test: `packages/expense-server/test/http.test.ts`
+
+- [x] **Step 1: Write failing ledger tests for create group, log expense, balance, history, and settlement intent**
+- [x] **Step 2: Run tests and verify they fail because server modules do not exist**
+- [x] **Step 3: Implement in-memory repository and ledger service**
+- [x] **Step 4: Write failing HTTP tests for `/health`, group creation, expense creation, balance, history, and settlement intent**
+- [x] **Step 5: Implement Node HTTP routing**
+- [x] **Step 6: Run server tests and verify they pass**
+
+### Task 3: CLI Expenses Commands
+
+**Files:**
+- Create: `packages/cli/src/lib/expenses-config.ts`
+- Create: `packages/cli/src/lib/expenses-client.ts`
+- Create: `packages/cli/src/commands/expenses.ts`
+- Modify: `packages/cli/src/cli.ts`
+- Test: `packages/cli/test/expenses.test.ts`
+
+- [x] **Step 1: Write failing CLI tests for setup, group create, log, balance, history, and settle**
+- [x] **Step 2: Run tests and verify they fail because commands are missing**
+- [x] **Step 3: Implement config helpers and HTTP client**
+- [x] **Step 4: Implement CLI commands and register them in `createCli()`**
+- [x] **Step 5: Run CLI tests and verify they pass**
+
+### Task 4: Workspace Wiring And Docs
+
+**Files:**
+- Modify: `package.json`
+- Modify: `tsconfig.json`
+- Modify: `docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md`
+- Modify: `skills/trusted-agents/SKILL.md`
+
+- [x] **Step 1: Add new packages to build/typecheck scripts**
+- [x] **Step 2: Update the design spec to reflect the simplified first implementation**
+- [x] **Step 3: Document the new `tap expenses` commands in the canonical TAP skill**
+- [x] **Step 4: Run targeted package tests, typecheck, and lint**

--- a/docs/superpowers/plans/2026-04-23-shared-expense-ledger-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-shared-expense-ledger-implementation.md
@@ -43,7 +43,7 @@
 
 - [x] **Step 1: Write failing ledger tests for create group, log expense, balance, history, and settlement intent**
 - [x] **Step 2: Run tests and verify they fail because server modules do not exist**
-- [x] **Step 3: Implement in-memory repository and ledger service**
+- [x] **Step 3: Implement in-memory/file-backed repositories and ledger service**
 - [x] **Step 4: Write failing HTTP tests for `/health`, group creation, expense creation, balance, history, and settlement intent**
 - [x] **Step 5: Implement Node HTTP routing**
 - [x] **Step 6: Run server tests and verify they pass**

--- a/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
+++ b/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
@@ -158,7 +158,7 @@ Do not overload `transfer/request` grants for expense settlement. Expense settle
 Add focused commands:
 
 ```bash
-tap expenses setup --server https://expenses.example.com
+tap expenses setup --server https://expenses.example.com --api-token $EXPENSE_SERVER_API_TOKEN
 tap expenses group create Bob --split equal --settle-threshold 25 --chain base
 tap expenses log Bob 45 "groceries" --category household
 tap expenses balance Bob
@@ -260,7 +260,13 @@ The model does not block these later, but v1 ships the smallest useful loop: log
 
 ## Implementation Defaults
 
-Use a TypeScript Node service for `packages/expense-server`, with a small Node HTTP API and an `ExpenseStore` repository interface. The first implementation ships an in-memory store for tests and local development. A durable Postgres store can replace that interface later without changing the TAP app, CLI commands, or HTTP API.
+Use a TypeScript Node service for `packages/expense-server`, with a small Node HTTP API and an `ExpenseStore` repository interface. The server binary uses a file-backed store by default (`EXPENSE_SERVER_DATA_FILE`) and the tests use an in-memory store. A durable Postgres store can replace that interface later without changing the TAP app, CLI commands, or HTTP API.
+
+HTTP defaults:
+- `GET /health` is public
+- all ledger routes require `Authorization: Bearer <token>` when `EXPENSE_SERVER_API_TOKEN` is configured
+- binding outside loopback requires `EXPENSE_SERVER_API_TOKEN`
+- CLI clients can store the token with `tap expenses setup --api-token` or read it from `TAP_EXPENSES_API_TOKEN`
 
 Settlement defaults:
 - groups default to manual settlement

--- a/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
+++ b/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
@@ -260,7 +260,7 @@ The model does not block these later, but v1 ships the smallest useful loop: log
 
 ## Implementation Defaults
 
-Use a TypeScript Node service for `packages/expense-server`, with Fastify for the public HTTP API and PostgreSQL as the durable system of record. Keep the ledger storage behind a repository interface so unit tests can use an in-memory implementation and integration tests can use an isolated Postgres database.
+Use a TypeScript Node service for `packages/expense-server`, with a small Node HTTP API and an `ExpenseStore` repository interface. The first implementation ships an in-memory store for tests and local development. A durable Postgres store can replace that interface later without changing the TAP app, CLI commands, or HTTP API.
 
 Settlement defaults:
 - groups default to manual settlement

--- a/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
+++ b/docs/superpowers/specs/2026-04-23-shared-expense-ledger-design.md
@@ -1,0 +1,269 @@
+# Shared Expense Ledger Design
+
+## Problem
+
+Issue #37 proposes a shared expense tab between agents. The core product need is not a one-off split payment. It is an ongoing financial relationship where agents can log expenses as they happen, keep a shared balance, and settle the net amount later.
+
+The first implementation uses a centralized server we control for the expense ledger and netting logic. Expenses do not create on-chain transactions. Settlement happens later in USDC on the chain chosen by the agents.
+
+## Decision
+
+Build v1 as a non-custodial centralized expense ledger with agent-executed USDC settlement.
+
+The server is authoritative for expenses, splits, balances, settlement intents, and settlement verification. It does not custody user funds and does not broadcast settlement transactions. Agents keep custody of their own USDC and execute the final net transfer from their own wallet when settlement is approved or covered by a grant.
+
+This gives the product the UX benefit of a centralized ledger while preserving the existing TAP trust model: no per-expense gas cost, no server custody, and only one on-chain USDC transfer when a tab is settled.
+
+## Package Shape
+
+Add `packages/app-expenses` as the TAP-facing expense app.
+
+It owns:
+- expense action payload builders
+- expense payload parsing and validation helpers
+- expense grant matching helpers
+- public types for expense events, splits, balances, and settlement intents
+- TAP app metadata for expense-related action types
+
+Add a centralized `packages/expense-server` service.
+
+It owns:
+- agent authentication against TAP identity signatures
+- append-only expense event storage
+- split and balance computation
+- settlement intent creation
+- settlement proof verification against chain RPC
+- notifications to participating agents
+
+Keep protocol and wallet execution logic out of the server package unless it is server-specific. TAP wire method names stay in `packages/core`. Wallet signing and USDC transfer execution stay with the agent runtime.
+
+## TAP Actions
+
+Use TAP action requests for peer-visible workflow events, not as the source of truth.
+
+Initial action types:
+- `expense/group.invite`
+- `expense/group.accept`
+- `expense/created`
+- `expense/acknowledge`
+- `expense/dispute`
+- `expense/adjust`
+- `expense/settlement.intent`
+- `expense/settlement.completed`
+- `expense/settlement.failed`
+
+The central server remains the financial source of truth. TAP conversations provide user-visible history and agent notifications.
+
+## Server Data Model
+
+Use an append-only event model with materialized views.
+
+Primary records:
+- `expense_groups`: relationship/context, usually one group per connected peer pair in v1
+- `expense_group_members`: agent ids, chains, wallet addresses, display names, roles
+- `expense_events`: signed immutable events such as create, acknowledge, dispute, adjust, settlement intent created, settlement completed
+- `expense_splits`: derived accounting rows per participant, stored in USDC minor units
+- `balances`: materialized net balance per pair/group, rebuildable from events
+- `settlement_intents`: net settlement instructions created by the server
+- `settlement_proofs`: tx hash, chain, verification result, and failure reason if any
+
+Do not edit posted financial events. Corrections create new reversal or delta events linked to the original event.
+
+## Expense Event Shape
+
+An expense creation event contains:
+- `eventId`
+- `groupId`
+- `idempotencyKey`
+- `creator`: TAP agent id and CAIP-2 chain
+- `paidBy`: TAP agent id and CAIP-2 chain
+- `amountMinor`
+- `asset`: `usdc`
+- `expenseCurrency`: default `USD`
+- `description`
+- `category`
+- `occurredAt`
+- `participants`
+- `split`: equal, shares, percentages, or exact minor units
+- optional receipt attachment metadata
+- previous event link when this is an adjustment
+- signature over the canonical payload
+
+For v1, keep currency conversion out of scope. If a receipt was paid in another currency, the client must submit a USDC-denominated value.
+
+## Settlement Intent Shape
+
+A settlement intent contains:
+- `intentId`
+- `groupId`
+- `debtor`
+- `creditor`
+- `amountMinor`
+- `asset`: `usdc`
+- `chain`
+- `tokenAddress`
+- `fromAddress`
+- `toAddress`
+- `reason`: threshold, schedule, or manual
+- `expiresAt`
+- `status`: pending, approved, submitted, completed, failed, expired, canceled
+- `idempotencyKey`
+
+The debtor agent executes the transfer. The server only verifies the result.
+
+## Settlement Verification
+
+The server marks settlement complete only after verifying all of:
+- transaction exists on the expected chain
+- transaction receipt succeeded
+- transfer uses the expected USDC token contract
+- sender matches the debtor execution address
+- recipient matches the creditor settlement address
+- amount equals the settlement intent amount
+- tx hash has not already been used for another settlement
+- transfer happened after the intent was created and before expiry, unless manually overridden
+
+If verification fails, keep the settlement intent pending or failed with a clear reason. Do not mutate the balance as settled until verification succeeds.
+
+## Grants And Approval
+
+Add an expense settlement grant scope:
+
+```json
+{
+	"scope": "expense/settle",
+	"constraints": {
+		"asset": "usdc",
+		"chains": ["eip155:8453"],
+		"maxAmount": "100",
+		"threshold": "25",
+		"schedule": "weekly"
+	}
+}
+```
+
+Grant constraint names for v1 are fixed as:
+- `asset`: currently `usdc`
+- `chains`: CAIP-2 chains where the grant applies
+- `maxAmount`: maximum single settlement amount in decimal USDC
+- `threshold`: minimum net owed amount before automatic threshold settlement
+- `schedule`: `manual`, `daily`, `weekly`, or `monthly`
+
+If a settlement intent is covered by an active grant, the debtor agent may execute automatically. If no grant covers it, the debtor sees a pending approval and can approve or deny.
+
+Do not overload `transfer/request` grants for expense settlement. Expense settlement is a different product permission because it has recurring relationship context, server-calculated netting, and a different audit trail.
+
+## CLI UX
+
+Add focused commands:
+
+```bash
+tap expenses setup --server https://expenses.example.com
+tap expenses group create Bob --split equal --settle-threshold 25 --chain base
+tap expenses log Bob 45 "groceries" --category household
+tap expenses balance Bob
+tap expenses history Bob
+tap expenses settle Bob
+tap expenses dispute <expense-id> --reason "wrong amount"
+```
+
+The natural language agent path maps to these commands or SDK calls:
+
+> Log $45 groceries, split with Bob.
+
+Expected behavior:
+- record the expense with the server
+- notify Bob's agent
+- update both agents' local conversation history
+- do not transfer USDC until settlement
+
+## Agent/Server Authentication
+
+Agents authenticate to the server with a signed challenge using their existing TAP identity. The server verifies:
+- agent id and chain
+- registration ownership/address
+- signature freshness
+- nonce replay protection
+
+Each expense event is also signed. Server sessions make repeated calls ergonomic, but signed events keep the ledger auditable.
+
+One-to-one expense groups are auto-created on first log when both agents are already connected TAP contacts. `tap expenses group create` remains available for explicit configuration before the first expense. Auto-created groups default to equal splits, manual settlement, and the local agent's configured chain.
+
+## Receipt Attachments
+
+Receipts are optional in v1.
+
+If included, store only metadata in the expense event:
+- content hash
+- MIME type
+- byte size
+- storage URL or object key
+
+Use S3-compatible object storage for receipt blobs. The server issues short-lived upload URLs and stores only receipt metadata in the event. Do not put large receipts in TAP messages.
+
+## Error Handling
+
+Server responses should be explicit and machine-readable:
+- `UNAUTHENTICATED`
+- `NOT_GROUP_MEMBER`
+- `DUPLICATE_IDEMPOTENCY_KEY`
+- `INVALID_SPLIT`
+- `UNSUPPORTED_ASSET`
+- `SETTLEMENT_BELOW_THRESHOLD`
+- `INSUFFICIENT_GRANT`
+- `SETTLEMENT_EXPIRED`
+- `TX_NOT_FOUND`
+- `TX_TOKEN_MISMATCH`
+- `TX_AMOUNT_MISMATCH`
+- `TX_SENDER_MISMATCH`
+- `TX_RECIPIENT_MISMATCH`
+- `TX_ALREADY_USED`
+
+Settlement failures should not erase or rewrite the owed balance. They only update the settlement intent/proof state.
+
+## Testing
+
+Unit tests:
+- split math and rounding
+- idempotency handling
+- event signature validation
+- reversal/adjustment logic
+- balance rebuilding from events
+- settlement intent threshold logic
+- grant matching for `expense/settle`
+- tx verification success and failure cases
+
+Integration tests:
+- two-agent expense logging with mocked server
+- server-created settlement intent to debtor agent
+- debtor agent executing a mocked USDC transfer
+- server verification marking settlement complete
+- duplicate tx hash rejected
+- dispute/adjustment flow changes balance without mutating prior events
+
+E2E tests:
+- mocked E2E in `packages/cli/test/e2e/e2e-mock.test.ts` for expense log, balance, and settlement instruction
+- live E2E is optional at first and only runs settlement on a funded test wallet when explicitly enabled
+
+## Out Of Scope For V1
+
+- server custody of funds
+- server-broadcast transfers
+- multi-currency conversion
+- multi-party groups larger than two agents
+- receipt OCR
+- on-chain expense registry
+- fiat bank settlement
+- recurring subscription-like pulls
+
+The model does not block these later, but v1 ships the smallest useful loop: log expense, show balance, settle net USDC transfer.
+
+## Implementation Defaults
+
+Use a TypeScript Node service for `packages/expense-server`, with Fastify for the public HTTP API and PostgreSQL as the durable system of record. Keep the ledger storage behind a repository interface so unit tests can use an in-memory implementation and integration tests can use an isolated Postgres database.
+
+Settlement defaults:
+- groups default to manual settlement
+- v1 supports manual, threshold, and scheduled settlement triggers
+- scheduled settlement means the server creates a settlement intent on the configured interval, but the debtor agent still needs either a covering `expense/settle` grant or explicit approval before USDC moves
+- automatic execution only happens on the debtor agent, never from the server

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {
-    "build": "bun run --cwd packages/core build && bun run --cwd packages/app-transfer build && bun run --cwd packages/app-scheduling build && bun run --cwd packages/sdk build && bun run --cwd packages/ui build && bun run --cwd packages/tapd build && bun run --cwd packages/cli build && bun run --cwd packages/openclaw-plugin build",
+    "build": "bun run --cwd packages/core build && bun run --cwd packages/app-transfer build && bun run --cwd packages/app-scheduling build && bun run --cwd packages/app-expenses build && bun run --cwd packages/expense-server build && bun run --cwd packages/sdk build && bun run --cwd packages/ui build && bun run --cwd packages/tapd build && bun run --cwd packages/cli build && bun run --cwd packages/openclaw-plugin build",
     "test": "vitest run",
     "test:xmtp": "XMTP_INTEGRATION=true vitest run packages/core/test/integration/xmtp-transport.test.ts",
     "test:watch": "vitest",
-    "typecheck": "bun run --cwd packages/core typecheck && bun run --cwd packages/core build && bun run --cwd packages/app-transfer typecheck && bun run --cwd packages/app-scheduling typecheck && bun run --cwd packages/sdk typecheck && bun run --cwd packages/sdk build && bun run --cwd packages/tapd typecheck && bun run --cwd packages/tapd build && bun run --cwd packages/ui typecheck && bun run --cwd packages/cli typecheck && bun run --cwd packages/openclaw-plugin typecheck",
+    "typecheck": "bun run --cwd packages/core typecheck && bun run --cwd packages/core build && bun run --cwd packages/app-transfer typecheck && bun run --cwd packages/app-scheduling typecheck && bun run --cwd packages/app-expenses typecheck && bun run --cwd packages/app-expenses build && bun run --cwd packages/expense-server typecheck && bun run --cwd packages/expense-server build && bun run --cwd packages/sdk typecheck && bun run --cwd packages/sdk build && bun run --cwd packages/tapd typecheck && bun run --cwd packages/tapd build && bun run --cwd packages/ui typecheck && bun run --cwd packages/cli typecheck && bun run --cwd packages/openclaw-plugin typecheck",
     "release:check": "bun run lint && bun run typecheck && bun run build && bun run test && bun run verify:release",
     "verify:release": "node scripts/verify-release-packages.mjs",
     "lint": "biome check .",

--- a/packages/app-expenses/package.json
+++ b/packages/app-expenses/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@trustedagents/app-expenses",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsc -b",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"trusted-agents-core": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^25.3.3"
+	}
+}

--- a/packages/app-expenses/src/amounts.ts
+++ b/packages/app-expenses/src/amounts.ts
@@ -1,0 +1,72 @@
+import type { ExpenseParticipant, ExpenseSplitShare } from "./types.js";
+
+const USDC_DECIMALS = 6;
+const USDC_SCALE = 10n ** BigInt(USDC_DECIMALS);
+
+export function parseUsdcAmount(input: string): bigint {
+	const trimmed = input.trim();
+	if (/^-/.test(trimmed)) {
+		throw new Error("USDC amount must be positive");
+	}
+
+	if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+		throw new Error(`Invalid USDC amount: ${input}`);
+	}
+
+	const [wholeRaw, fractionRaw = ""] = trimmed.split(".");
+	if (fractionRaw.length > USDC_DECIMALS) {
+		throw new Error("USDC amount must have at most 6 decimal places");
+	}
+
+	const whole = BigInt(wholeRaw ?? "0");
+	const fraction = BigInt(fractionRaw.padEnd(USDC_DECIMALS, "0"));
+	const minor = whole * USDC_SCALE + fraction;
+	if (minor <= 0n) {
+		throw new Error("USDC amount must be positive");
+	}
+	return minor;
+}
+
+export function formatUsdcMinor(minor: bigint | string): string {
+	const value = typeof minor === "bigint" ? minor : BigInt(minor);
+	const whole = value / USDC_SCALE;
+	const fraction = value % USDC_SCALE;
+	if (fraction === 0n) {
+		return whole.toString();
+	}
+	return `${whole}.${fraction.toString().padStart(USDC_DECIMALS, "0").replace(/0+$/, "")}`;
+}
+
+export function buildEqualSplits(
+	amountMinor: bigint,
+	participants: ExpenseParticipant[],
+): ExpenseSplitShare[] {
+	if (participants.length === 0) {
+		throw new Error("At least one participant is required");
+	}
+
+	const share = amountMinor / BigInt(participants.length);
+	let remainder = amountMinor % BigInt(participants.length);
+	return participants.map((participant) => {
+		const extra = remainder > 0n ? 1n : 0n;
+		remainder -= extra;
+		return {
+			agentId: participant.agentId,
+			chain: participant.chain,
+			amountMinor: (share + extra).toString(),
+		};
+	});
+}
+
+export function deriveExpenseGroupId(participants: ExpenseParticipant[]): string {
+	if (participants.length < 2) {
+		throw new Error("At least two participants are required");
+	}
+
+	const normalized = participants
+		.map((participant) => `${participant.chain}:${participant.agentId}`)
+		.sort()
+		.map((value) => value.replace(/[^a-zA-Z0-9]+/g, "_"));
+
+	return `expgrp_${normalized.join("_")}`;
+}

--- a/packages/app-expenses/src/grants.ts
+++ b/packages/app-expenses/src/grants.ts
@@ -1,0 +1,82 @@
+import type { PermissionGrant, PermissionGrantSet } from "trusted-agents-core";
+import { parseUsdcAmount } from "./amounts.js";
+import {
+	EXPENSE_SETTLE_SCOPE,
+	type ExpenseSettlementGrantRequest,
+	type ExpenseSettlementSchedule,
+} from "./types.js";
+
+export function findApplicableExpenseSettlementGrants(
+	grantSet: PermissionGrantSet,
+	request: ExpenseSettlementGrantRequest,
+): PermissionGrant[] {
+	return grantSet.grants.filter(
+		(grant) =>
+			grant.status === "active" &&
+			grant.scope === EXPENSE_SETTLE_SCOPE &&
+			matchesExpenseSettlementGrant(grant, request),
+	);
+}
+
+export function matchesExpenseSettlementGrant(
+	grant: PermissionGrant,
+	request: ExpenseSettlementGrantRequest,
+): boolean {
+	const constraints = grant.constraints;
+	if (!constraints) {
+		return true;
+	}
+
+	if (typeof constraints.asset === "string" && constraints.asset !== request.asset) {
+		return false;
+	}
+
+	if (Array.isArray(constraints.chains)) {
+		const chains = constraints.chains.filter((chain): chain is string => typeof chain === "string");
+		if (chains.length > 0 && !chains.includes(request.chain)) {
+			return false;
+		}
+	}
+
+	if (typeof constraints.maxAmount === "string") {
+		try {
+			if (parseUsdcAmount(request.amount) > parseUsdcAmount(constraints.maxAmount)) {
+				return false;
+			}
+		} catch {
+			return false;
+		}
+	}
+
+	if (request.reason === "threshold" && typeof constraints.threshold === "string") {
+		try {
+			if (parseUsdcAmount(request.amount) < parseUsdcAmount(constraints.threshold)) {
+				return false;
+			}
+		} catch {
+			return false;
+		}
+	}
+
+	if (typeof constraints.schedule === "string") {
+		if (!matchesScheduleConstraint(constraints.schedule, request.reason, request.schedule)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function matchesScheduleConstraint(
+	constraint: string,
+	reason: ExpenseSettlementGrantRequest["reason"],
+	schedule: ExpenseSettlementSchedule | undefined,
+): boolean {
+	if (constraint === "manual") {
+		return reason === "manual";
+	}
+	if (reason !== "schedule") {
+		return true;
+	}
+	return schedule === constraint;
+}

--- a/packages/app-expenses/src/grants.ts
+++ b/packages/app-expenses/src/grants.ts
@@ -75,6 +75,9 @@ function matchesScheduleConstraint(
 	if (constraint === "manual") {
 		return reason === "manual";
 	}
+	if (reason === "manual") {
+		return false;
+	}
 	if (reason !== "schedule") {
 		return true;
 	}

--- a/packages/app-expenses/src/index.ts
+++ b/packages/app-expenses/src/index.ts
@@ -1,0 +1,79 @@
+import { defineTapApp } from "trusted-agents-core";
+
+export * from "./amounts.js";
+export * from "./grants.js";
+export * from "./types.js";
+
+export const expenseApp = defineTapApp({
+	id: "expenses",
+	name: "Shared Expenses",
+	version: "1.0.0",
+	actions: {
+		"expense/group.invite": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/group.invite", summary: "Expense group invite received" });
+				return { success: true };
+			},
+		},
+		"expense/group.accept": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/group.accept", summary: "Expense group accepted" });
+				return { success: true };
+			},
+		},
+		"expense/created": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/created", summary: "Expense recorded" });
+				return { success: true };
+			},
+		},
+		"expense/acknowledge": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/acknowledge", summary: "Expense acknowledged" });
+				return { success: true };
+			},
+		},
+		"expense/dispute": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/dispute", summary: "Expense disputed" });
+				return { success: true };
+			},
+		},
+		"expense/adjust": {
+			handler: async (ctx) => {
+				ctx.events.emit({ type: "expense/adjust", summary: "Expense adjusted" });
+				return { success: true };
+			},
+		},
+		"expense/settlement.intent": {
+			handler: async (ctx) => {
+				ctx.events.emit({
+					type: "expense/settlement.intent",
+					summary: "Expense settlement requested",
+				});
+				return { success: true };
+			},
+		},
+		"expense/settlement.completed": {
+			handler: async (ctx) => {
+				ctx.events.emit({
+					type: "expense/settlement.completed",
+					summary: "Expense settlement completed",
+				});
+				return { success: true };
+			},
+		},
+		"expense/settlement.failed": {
+			handler: async (ctx) => {
+				ctx.events.emit({
+					type: "expense/settlement.failed",
+					summary: "Expense settlement failed",
+				});
+				return { success: true };
+			},
+		},
+	},
+	grantScopes: ["expense/settle"],
+});
+
+export default expenseApp;

--- a/packages/app-expenses/src/types.ts
+++ b/packages/app-expenses/src/types.ts
@@ -1,0 +1,84 @@
+export const EXPENSE_SETTLE_SCOPE = "expense/settle" as const;
+
+export type ExpenseAsset = "usdc";
+export type ExpenseSettlementReason = "manual" | "threshold" | "schedule";
+export type ExpenseSettlementSchedule = "manual" | "daily" | "weekly" | "monthly";
+
+export interface ExpenseParticipant {
+	agentId: number;
+	chain: string;
+	displayName?: string;
+	address?: `0x${string}`;
+}
+
+export interface ExpenseSplitShare {
+	agentId: number;
+	chain: string;
+	amountMinor: string;
+}
+
+export interface ExpenseGroup {
+	groupId: string;
+	members: ExpenseParticipant[];
+	split: "equal";
+	chain: string;
+	asset: ExpenseAsset;
+	settlementThresholdMinor?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface ExpenseRecord {
+	eventId: string;
+	groupId: string;
+	idempotencyKey: string;
+	creator: ExpenseParticipant;
+	paidBy: ExpenseParticipant;
+	amountMinor: string;
+	asset: ExpenseAsset;
+	expenseCurrency: "USD";
+	description: string;
+	category?: string;
+	occurredAt: string;
+	participants: ExpenseParticipant[];
+	splits: ExpenseSplitShare[];
+	createdAt: string;
+}
+
+export interface ExpenseBalanceShare {
+	agentId: number;
+	chain: string;
+	netMinor: string;
+}
+
+export interface ExpenseBalance {
+	groupId: string;
+	asset: ExpenseAsset;
+	shares: ExpenseBalanceShare[];
+}
+
+export interface ExpenseSettlementIntent {
+	intentId: string;
+	groupId: string;
+	debtor: ExpenseParticipant;
+	creditor: ExpenseParticipant;
+	amountMinor: string;
+	asset: ExpenseAsset;
+	chain: string;
+	tokenAddress?: `0x${string}`;
+	fromAddress?: `0x${string}`;
+	toAddress?: `0x${string}`;
+	reason: ExpenseSettlementReason;
+	status: "pending" | "submitted" | "completed" | "failed" | "expired" | "canceled";
+	idempotencyKey: string;
+	createdAt: string;
+	expiresAt: string;
+}
+
+export interface ExpenseSettlementGrantRequest {
+	asset: ExpenseAsset;
+	amount: string;
+	chain: string;
+	reason: ExpenseSettlementReason;
+	schedule?: ExpenseSettlementSchedule;
+}

--- a/packages/app-expenses/test/amounts.test.ts
+++ b/packages/app-expenses/test/amounts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildEqualSplits,
+	deriveExpenseGroupId,
+	formatUsdcMinor,
+	parseUsdcAmount,
+} from "../src/index.js";
+
+describe("expense amount helpers", () => {
+	it("parses decimal USDC amounts into minor units", () => {
+		expect(parseUsdcAmount("45")).toBe(45_000_000n);
+		expect(parseUsdcAmount("22.50")).toBe(22_500_000n);
+		expect(parseUsdcAmount("0.000001")).toBe(1n);
+	});
+
+	it("rejects invalid or over-precise USDC amounts", () => {
+		expect(() => parseUsdcAmount("0")).toThrow("positive");
+		expect(() => parseUsdcAmount("-1")).toThrow("positive");
+		expect(() => parseUsdcAmount("1.0000001")).toThrow("at most 6 decimal places");
+		expect(() => parseUsdcAmount("abc")).toThrow("Invalid USDC amount");
+	});
+
+	it("formats minor units back into decimal USDC", () => {
+		expect(formatUsdcMinor(45_000_000n)).toBe("45");
+		expect(formatUsdcMinor(22_500_000n)).toBe("22.5");
+		expect(formatUsdcMinor(1n)).toBe("0.000001");
+	});
+
+	it("splits remainders deterministically by participant order", () => {
+		const splits = buildEqualSplits(10_000_001n, [
+			{ agentId: 2, chain: "eip155:8453" },
+			{ agentId: 1, chain: "eip155:8453" },
+		]);
+
+		expect(splits).toEqual([
+			{ agentId: 2, chain: "eip155:8453", amountMinor: "5000001" },
+			{ agentId: 1, chain: "eip155:8453", amountMinor: "5000000" },
+		]);
+	});
+
+	it("derives a stable group id independent of participant order", () => {
+		const left = deriveExpenseGroupId([
+			{ agentId: 2, chain: "eip155:8453" },
+			{ agentId: 1, chain: "eip155:8453" },
+		]);
+		const right = deriveExpenseGroupId([
+			{ agentId: 1, chain: "eip155:8453" },
+			{ agentId: 2, chain: "eip155:8453" },
+		]);
+
+		expect(left).toBe(right);
+		expect(left).toBe("expgrp_eip155_8453_1_eip155_8453_2");
+	});
+});

--- a/packages/app-expenses/test/grants.test.ts
+++ b/packages/app-expenses/test/grants.test.ts
@@ -82,4 +82,15 @@ describe("expense settlement grants", () => {
 			}),
 		).toHaveLength(1);
 	});
+
+	it("does not use scheduled grants for manual settlement", () => {
+		expect(
+			findApplicableExpenseSettlementGrants(grantSet, {
+				asset: "usdc",
+				amount: "50",
+				chain: "eip155:8453",
+				reason: "manual",
+			}),
+		).toHaveLength(0);
+	});
 });

--- a/packages/app-expenses/test/grants.test.ts
+++ b/packages/app-expenses/test/grants.test.ts
@@ -1,0 +1,85 @@
+import type { PermissionGrantSet } from "trusted-agents-core";
+import { describe, expect, it } from "vitest";
+import { findApplicableExpenseSettlementGrants } from "../src/index.js";
+
+const grantSet = {
+	version: "tap-grants/v1",
+	updatedAt: "2026-04-23T00:00:00.000Z",
+	grants: [
+		{
+			grantId: "weekly-base",
+			scope: "expense/settle",
+			status: "active",
+			updatedAt: "2026-04-23T00:00:00.000Z",
+			constraints: {
+				asset: "usdc",
+				chains: ["eip155:8453"],
+				maxAmount: "100",
+				threshold: "25",
+				schedule: "weekly",
+			},
+		},
+		{
+			grantId: "revoked",
+			scope: "expense/settle",
+			status: "revoked",
+			updatedAt: "2026-04-23T00:00:00.000Z",
+		},
+	],
+} satisfies PermissionGrantSet;
+
+describe("expense settlement grants", () => {
+	it("matches active grants that cover amount, chain, asset, threshold, and schedule", () => {
+		const matches = findApplicableExpenseSettlementGrants(grantSet, {
+			asset: "usdc",
+			amount: "50",
+			chain: "eip155:8453",
+			reason: "schedule",
+			schedule: "weekly",
+		});
+
+		expect(matches.map((grant) => grant.grantId)).toEqual(["weekly-base"]);
+	});
+
+	it("rejects grants when amount or chain is outside constraints", () => {
+		expect(
+			findApplicableExpenseSettlementGrants(grantSet, {
+				asset: "usdc",
+				amount: "101",
+				chain: "eip155:8453",
+				reason: "schedule",
+				schedule: "weekly",
+			}),
+		).toHaveLength(0);
+
+		expect(
+			findApplicableExpenseSettlementGrants(grantSet, {
+				asset: "usdc",
+				amount: "50",
+				chain: "eip155:167000",
+				reason: "schedule",
+				schedule: "weekly",
+			}),
+		).toHaveLength(0);
+	});
+
+	it("requires threshold settlements to meet the configured threshold", () => {
+		expect(
+			findApplicableExpenseSettlementGrants(grantSet, {
+				asset: "usdc",
+				amount: "24.99",
+				chain: "eip155:8453",
+				reason: "threshold",
+			}),
+		).toHaveLength(0);
+
+		expect(
+			findApplicableExpenseSettlementGrants(grantSet, {
+				asset: "usdc",
+				amount: "25",
+				chain: "eip155:8453",
+				reason: "threshold",
+			}),
+		).toHaveLength(1);
+	});
+});

--- a/packages/app-expenses/tsconfig.json
+++ b/packages/app-expenses/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"composite": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/app-expenses/vitest.config.ts
+++ b/packages/app-expenses/vitest.config.ts
@@ -10,11 +10,6 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"trusted-agents-core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
-			"trusted-agents-sdk": path.resolve(import.meta.dirname, "../sdk/src/index.ts"),
-			"@trustedagents/app-expenses": path.resolve(
-				import.meta.dirname,
-				"../app-expenses/src/index.ts",
-			),
 		},
 	},
 });

--- a/packages/cli/assets/skills/trusted-agents/SKILL.md
+++ b/packages/cli/assets/skills/trusted-agents/SKILL.md
@@ -399,7 +399,7 @@ In OpenClaw or Hermes plugin mode, use `tap_gateway transfer` with `asset`, `amo
 Shared expenses keep an off-chain tab with a connected peer and settle only the net balance in USDC. Expenses are recorded through the configured expense server; the server does not custody funds or broadcast transfers.
 
 ```bash
-tap expenses setup --server https://expenses.example.com --settlement-address 0x1111111111111111111111111111111111111111
+tap expenses setup --server https://expenses.example.com --api-token $EXPENSE_SERVER_API_TOKEN --settlement-address 0x1111111111111111111111111111111111111111
 tap expenses group create Bob --settle-threshold 25
 tap expenses log Bob 45 "groceries" --category household --idempotency-key groceries-2026-04-23
 tap expenses balance Bob
@@ -410,6 +410,8 @@ tap expenses settle Bob --idempotency-key settle-2026-week-17
 Flow: setup server -> create or auto-create peer group -> log expenses without on-chain transactions -> inspect net balance -> create settlement intent for one USDC transfer. Positive balances mean the agent is owed USDC; negative balances mean the agent owes USDC.
 
 Use `expense/settle` grants for automatic settlement policy. Do not reuse `transfer/request` grants for shared-expense settlement; shared expenses have their own ledger and netting context.
+
+The standalone expense server reads `EXPENSE_SERVER_DATA_FILE` for its durable ledger path and `EXPENSE_SERVER_API_TOKEN` for bearer authentication. Binding the server outside loopback requires `EXPENSE_SERVER_API_TOKEN`. Clients can configure the bearer token with `tap expenses setup --api-token` or `TAP_EXPENSES_API_TOKEN`.
 
 ## Meeting Scheduling
 

--- a/packages/cli/assets/skills/trusted-agents/SKILL.md
+++ b/packages/cli/assets/skills/trusted-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trusted-agents
-description: Operate a Trusted Agents Protocol agent with the `tap` CLI — install, onboard, connect to other agents, manage permissions, send messages, request funds, and schedule meetings. Use this skill whenever the user wants to work with TAP, set up an agent identity, connect agents, exchange grants, schedule meetings or dinners, check calendar availability, or do anything involving agent-to-agent communication or on-chain identity — even if they don't explicitly say "TAP." Also use this skill when the user mentions scheduling, meetings, dinners, calendar setup, or coordinating times with another agent. Also use inside OpenClaw Gateway or Hermes when the `tap_gateway` tool is available or when handling TAP notifications.
+description: Operate a Trusted Agents Protocol agent with the `tap` CLI — install, onboard, connect to other agents, manage permissions, send messages, request funds, track shared expenses, and schedule meetings. Use this skill whenever the user wants to work with TAP, set up an agent identity, connect agents, exchange grants, split bills, schedule meetings or dinners, check calendar availability, or do anything involving agent-to-agent communication or on-chain identity — even if they don't explicitly say "TAP." Also use this skill when the user mentions scheduling, meetings, dinners, shared expenses, splitting bills, calendar setup, or coordinating times with another agent. Also use inside OpenClaw Gateway or Hermes when the `tap_gateway` tool is available or when handling TAP notifications.
 ---
 
 # Trusted Agents Protocol
@@ -335,6 +335,7 @@ See `references/permissions-v1.md` for the full JSON spec with all fields and ad
 | `research` | Questions, information gathering |
 | `scheduling/request` | Meeting scheduling — propose, counter, accept, reject, cancel |
 | `transfer/request` | Value movement |
+| `expense/settle` | Automatic shared-expense settlement permission |
 | `permissions/request-grants` | Ask for permissions |
 
 ## Messages
@@ -392,6 +393,23 @@ Validation errors:
 - unknown chain or `usdc` on a chain without a configured USDC token
 
 In OpenClaw or Hermes plugin mode, use `tap_gateway transfer` with `asset`, `amount`, `toAddress`, and optionally `chain` (defaults to configured chain, must be CAIP-2).
+
+## Shared Expenses
+
+Shared expenses keep an off-chain tab with a connected peer and settle only the net balance in USDC. Expenses are recorded through the configured expense server; the server does not custody funds or broadcast transfers.
+
+```bash
+tap expenses setup --server https://expenses.example.com --settlement-address 0x1111111111111111111111111111111111111111
+tap expenses group create Bob --settle-threshold 25
+tap expenses log Bob 45 "groceries" --category household --idempotency-key groceries-2026-04-23
+tap expenses balance Bob
+tap expenses history Bob
+tap expenses settle Bob --idempotency-key settle-2026-week-17
+```
+
+Flow: setup server -> create or auto-create peer group -> log expenses without on-chain transactions -> inspect net balance -> create settlement intent for one USDC transfer. Positive balances mean the agent is owed USDC; negative balances mean the agent owes USDC.
+
+Use `expense/settle` grants for automatic settlement policy. Do not reuse `transfer/request` grants for shared-expense settlement; shared expenses have their own ledger and netting context.
 
 ## Meeting Scheduling
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
     "@open-wallet-standard/core": "npm:@silicon-intern/ows-core@^1.2.0-eip712.3",
     "trusted-agents-sdk": "workspace:*",
     "trusted-agents-tapd": "workspace:*",
+    "@trustedagents/app-expenses": "workspace:*",
     "@x402/evm": "^2.5.0",
     "@x402/fetch": "^2.5.0",
     "commander": "^13.0.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -398,6 +398,80 @@ Examples:
 			},
 		);
 
+	const expenses = program
+		.command("expenses")
+		.description("Track shared expenses and settle net balances in USDC");
+
+	expenses
+		.command("setup")
+		.description("Configure the shared expense server for this agent")
+		.requiredOption("--server <url>", "Expense server base URL")
+		.option("--settlement-address <address>", "USDC settlement receiving address for this agent")
+		.action(async (cmdOpts: { server: string; settlementAddress?: string }) => {
+			const opts = program.opts<GlobalOptions>();
+			const { expensesSetupCommand } = await import("./commands/expenses.js");
+			await expensesSetupCommand(cmdOpts, opts);
+		});
+
+	const expensesGroup = expenses.command("group").description("Manage shared expense groups");
+
+	expensesGroup
+		.command("create <peer>")
+		.description("Create or update a one-to-one shared expense group")
+		.option("--settle-threshold <amount>", "USDC amount before threshold settlement")
+		.action(async (peer: string, cmdOpts: { settleThreshold?: string }) => {
+			const opts = program.opts<GlobalOptions>();
+			const { expensesGroupCreateCommand } = await import("./commands/expenses.js");
+			await expensesGroupCreateCommand(peer, cmdOpts, opts);
+		});
+
+	expenses
+		.command("log <peer> <amount> <description>")
+		.description("Log an expense paid by this agent and split with a peer")
+		.option("--category <name>", "Expense category")
+		.option("--idempotency-key <key>", "Idempotency key for retries")
+		.action(
+			async (
+				peer: string,
+				amount: string,
+				description: string,
+				cmdOpts: { category?: string; idempotencyKey?: string },
+			) => {
+				const opts = program.opts<GlobalOptions>();
+				const { expensesLogCommand } = await import("./commands/expenses.js");
+				await expensesLogCommand(peer, amount, description, cmdOpts, opts);
+			},
+		);
+
+	expenses
+		.command("balance <peer>")
+		.description("Show the shared expense balance with a peer")
+		.action(async (peer: string) => {
+			const opts = program.opts<GlobalOptions>();
+			const { expensesBalanceCommand } = await import("./commands/expenses.js");
+			await expensesBalanceCommand(peer, opts);
+		});
+
+	expenses
+		.command("history <peer>")
+		.description("Show shared expense history with a peer")
+		.action(async (peer: string) => {
+			const opts = program.opts<GlobalOptions>();
+			const { expensesHistoryCommand } = await import("./commands/expenses.js");
+			await expensesHistoryCommand(peer, opts);
+		});
+
+	expenses
+		.command("settle <peer>")
+		.description("Create a net USDC settlement intent with a peer")
+		.option("--idempotency-key <key>", "Idempotency key for retries")
+		.option("--reason <reason>", "Settlement reason: manual, threshold, or schedule", "manual")
+		.action(async (peer: string, cmdOpts: { idempotencyKey?: string; reason?: string }) => {
+			const opts = program.opts<GlobalOptions>();
+			const { expensesSettleCommand } = await import("./commands/expenses.js");
+			await expensesSettleCommand(peer, cmdOpts, opts);
+		});
+
 	// config
 	const config = program.command("config").description("Manage configuration");
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -407,7 +407,8 @@ Examples:
 		.description("Configure the shared expense server for this agent")
 		.requiredOption("--server <url>", "Expense server base URL")
 		.option("--settlement-address <address>", "USDC settlement receiving address for this agent")
-		.action(async (cmdOpts: { server: string; settlementAddress?: string }) => {
+		.option("--api-token <token>", "Bearer token for the expense server")
+		.action(async (cmdOpts: { server: string; settlementAddress?: string; apiToken?: string }) => {
 			const opts = program.opts<GlobalOptions>();
 			const { expensesSetupCommand } = await import("./commands/expenses.js");
 			await expensesSetupCommand(cmdOpts, opts);

--- a/packages/cli/src/commands/expenses.ts
+++ b/packages/cli/src/commands/expenses.ts
@@ -1,0 +1,289 @@
+import { randomUUID } from "node:crypto";
+import {
+	type ExpenseParticipant,
+	deriveExpenseGroupId,
+	formatUsdcMinor,
+} from "@trustedagents/app-expenses";
+import {
+	type Contact,
+	FileTrustStore,
+	type TrustedAgentsConfig,
+	findContactForPeer,
+} from "trusted-agents-core";
+import { loadConfig, resolveDataDir } from "../lib/config-loader.js";
+import { handleCommandError } from "../lib/errors.js";
+import { ExpensesClient } from "../lib/expenses-client.js";
+import {
+	normalizeExpenseSettlementAddress,
+	normalizeExpensesServerUrl,
+	readExpensesConfig,
+	writeExpensesConfig,
+} from "../lib/expenses-config.js";
+import { success } from "../lib/output.js";
+import type { GlobalOptions } from "../types.js";
+
+interface ExpensesSetupOptions {
+	server: string;
+	settlementAddress?: string;
+}
+
+interface ExpensesGroupCreateOptions {
+	settleThreshold?: string;
+}
+
+interface ExpensesLogOptions {
+	category?: string;
+	idempotencyKey?: string;
+}
+
+interface ExpensesSettleOptions {
+	idempotencyKey?: string;
+	reason?: string;
+}
+
+export async function expensesSetupCommand(
+	cmdOpts: ExpensesSetupOptions,
+	opts: GlobalOptions,
+): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const settlementAddress = cmdOpts.settlementAddress
+			? normalizeExpenseSettlementAddress(cmdOpts.settlementAddress)
+			: undefined;
+		const serverUrl = normalizeExpensesServerUrl(cmdOpts.server);
+		const result = await writeExpensesConfig(opts, {
+			serverUrl,
+			...(settlementAddress ? { settlementAddress } : {}),
+		});
+		success(
+			{
+				server_url: serverUrl,
+				...(settlementAddress ? { settlement_address: settlementAddress } : {}),
+				path: result.path,
+			},
+			opts,
+			startTime,
+		);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+export async function expensesGroupCreateCommand(
+	peer: string,
+	cmdOpts: ExpensesGroupCreateOptions,
+	opts: GlobalOptions,
+): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const context = await buildExpenseCommandContext(peer, opts);
+		const group = await context.client.createGroup({
+			members: context.members,
+			chain: context.config.chain,
+			...(cmdOpts.settleThreshold ? { settlementThreshold: cmdOpts.settleThreshold } : {}),
+		});
+		success(formatGroup(group), opts, startTime);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+export async function expensesLogCommand(
+	peer: string,
+	amount: string,
+	description: string,
+	cmdOpts: ExpensesLogOptions,
+	opts: GlobalOptions,
+): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const context = await buildExpenseCommandContext(peer, opts);
+		const groupId = deriveExpenseGroupId(context.members);
+		const expense = await context.client.logExpense({
+			groupId,
+			idempotencyKey: cmdOpts.idempotencyKey ?? `expense-${randomUUID()}`,
+			creator: context.self,
+			paidBy: context.self,
+			amount,
+			description,
+			...(cmdOpts.category ? { category: cmdOpts.category } : {}),
+			participants: context.members,
+		});
+		success(formatExpense(expense), opts, startTime);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+export async function expensesBalanceCommand(peer: string, opts: GlobalOptions): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const context = await buildExpenseCommandContext(peer, opts);
+		const balance = await context.client.getBalance(deriveExpenseGroupId(context.members));
+		success(formatBalance(balance), opts, startTime);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+export async function expensesHistoryCommand(peer: string, opts: GlobalOptions): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const context = await buildExpenseCommandContext(peer, opts);
+		const history = await context.client.getHistory(deriveExpenseGroupId(context.members));
+		const expenses = Array.isArray(history.expenses) ? history.expenses : [];
+		success(
+			{
+				group_id: String(history.groupId ?? deriveExpenseGroupId(context.members)),
+				expenses: expenses.map((expense) => formatExpense(expense as Record<string, unknown>)),
+			},
+			opts,
+			startTime,
+		);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+export async function expensesSettleCommand(
+	peer: string,
+	cmdOpts: ExpensesSettleOptions,
+	opts: GlobalOptions,
+): Promise<void> {
+	const startTime = Date.now();
+	try {
+		const context = await buildExpenseCommandContext(peer, opts);
+		const settlement = await context.client.createSettlement(
+			deriveExpenseGroupId(context.members),
+			{
+				reason: cmdOpts.reason ?? "manual",
+				idempotencyKey: cmdOpts.idempotencyKey ?? `settle-${randomUUID()}`,
+			},
+		);
+		success(formatSettlement(settlement), opts, startTime);
+	} catch (err) {
+		handleCommandError(err, opts);
+	}
+}
+
+async function buildExpenseCommandContext(
+	peer: string,
+	opts: GlobalOptions,
+): Promise<{
+	client: ExpensesClient;
+	config: TrustedAgentsConfig;
+	self: ExpenseParticipant;
+	members: ExpenseParticipant[];
+}> {
+	const config = await loadConfig(opts);
+	const expensesConfig = await readExpensesConfig(opts);
+	const contact = await resolvePeerContact(peer, resolveDataDir(opts));
+	const self: ExpenseParticipant = {
+		agentId: config.agentId,
+		chain: config.chain,
+		displayName: "Self",
+		...(expensesConfig.settlementAddress ? { address: expensesConfig.settlementAddress } : {}),
+	};
+	const peerParticipant = contactToParticipant(contact);
+	return {
+		client: new ExpensesClient(expensesConfig.serverUrl),
+		config,
+		self,
+		members: [self, peerParticipant],
+	};
+}
+
+async function resolvePeerContact(peer: string, dataDir: string): Promise<Contact> {
+	const store = new FileTrustStore(dataDir);
+	const contact = findContactForPeer(await store.getContacts(), peer);
+	if (!contact || contact.status !== "active") {
+		throw new Error(`No active TAP contact found for ${peer}`);
+	}
+	return contact;
+}
+
+function contactToParticipant(contact: Contact): ExpenseParticipant {
+	return {
+		agentId: contact.peerAgentId,
+		chain: contact.peerChain,
+		displayName: contact.peerDisplayName,
+		address: contact.peerAgentAddress,
+	};
+}
+
+function formatGroup(group: Record<string, unknown>): Record<string, unknown> {
+	return {
+		group_id: String(group.groupId),
+		chain: String(group.chain),
+		asset: String(group.asset),
+		members: Array.isArray(group.members)
+			? group.members.map((member) => formatParticipant(member as Record<string, unknown>))
+			: [],
+	};
+}
+
+function formatParticipant(participant: Record<string, unknown>): Record<string, unknown> {
+	return {
+		agent_id: Number(participant.agentId),
+		chain: String(participant.chain),
+		...(typeof participant.displayName === "string" ? { name: participant.displayName } : {}),
+		...(typeof participant.address === "string" ? { address: participant.address } : {}),
+	};
+}
+
+function formatExpense(expense: Record<string, unknown>): Record<string, unknown> {
+	return {
+		event_id: String(expense.eventId),
+		group_id: String(expense.groupId),
+		amount: formatUsdcMinor(String(expense.amountMinor)),
+		description: String(expense.description),
+		...(typeof expense.category === "string" ? { category: expense.category } : {}),
+		paid_by_agent_id: agentIdFrom(expense.paidBy),
+		created_at: String(expense.createdAt),
+	};
+}
+
+function formatBalance(balance: Record<string, unknown>): Record<string, unknown> {
+	const shares = Array.isArray(balance.shares) ? balance.shares : [];
+	return {
+		group_id: String(balance.groupId),
+		asset: String(balance.asset),
+		shares: shares.map((share) => {
+			const data = share as Record<string, unknown>;
+			return {
+				agent_id: Number(data.agentId),
+				chain: String(data.chain),
+				net_amount: formatSignedUsdc(String(data.netMinor)),
+			};
+		}),
+	};
+}
+
+function formatSettlement(settlement: Record<string, unknown>): Record<string, unknown> {
+	return {
+		intent_id: String(settlement.intentId),
+		group_id: String(settlement.groupId),
+		debtor_agent_id: agentIdFrom(settlement.debtor),
+		creditor_agent_id: agentIdFrom(settlement.creditor),
+		amount: formatUsdcMinor(String(settlement.amountMinor)),
+		chain: String(settlement.chain),
+		status: String(settlement.status),
+		...(typeof settlement.fromAddress === "string" ? { from_address: settlement.fromAddress } : {}),
+		...(typeof settlement.toAddress === "string" ? { to_address: settlement.toAddress } : {}),
+	};
+}
+
+function agentIdFrom(value: unknown): number {
+	if (typeof value === "object" && value !== null) {
+		return Number((value as { agentId?: unknown }).agentId);
+	}
+	return Number.NaN;
+}
+
+function formatSignedUsdc(value: string): string {
+	const minor = BigInt(value);
+	if (minor < 0n) {
+		return `-${formatUsdcMinor((-minor).toString())}`;
+	}
+	return formatUsdcMinor(minor.toString());
+}

--- a/packages/cli/src/commands/expenses.ts
+++ b/packages/cli/src/commands/expenses.ts
@@ -14,6 +14,7 @@ import { loadConfig, resolveDataDir } from "../lib/config-loader.js";
 import { handleCommandError } from "../lib/errors.js";
 import { ExpensesClient } from "../lib/expenses-client.js";
 import {
+	normalizeExpenseApiToken,
 	normalizeExpenseSettlementAddress,
 	normalizeExpensesServerUrl,
 	readExpensesConfig,
@@ -25,6 +26,7 @@ import type { GlobalOptions } from "../types.js";
 interface ExpensesSetupOptions {
 	server: string;
 	settlementAddress?: string;
+	apiToken?: string;
 }
 
 interface ExpensesGroupCreateOptions {
@@ -50,15 +52,18 @@ export async function expensesSetupCommand(
 		const settlementAddress = cmdOpts.settlementAddress
 			? normalizeExpenseSettlementAddress(cmdOpts.settlementAddress)
 			: undefined;
+		const apiToken = cmdOpts.apiToken ? normalizeExpenseApiToken(cmdOpts.apiToken) : undefined;
 		const serverUrl = normalizeExpensesServerUrl(cmdOpts.server);
 		const result = await writeExpensesConfig(opts, {
 			serverUrl,
 			...(settlementAddress ? { settlementAddress } : {}),
+			...(apiToken ? { apiToken } : {}),
 		});
 		success(
 			{
 				server_url: serverUrl,
 				...(settlementAddress ? { settlement_address: settlementAddress } : {}),
+				...(apiToken ? { api_token: "***redacted***" } : {}),
 				path: result.path,
 			},
 			opts,
@@ -186,7 +191,9 @@ async function buildExpenseCommandContext(
 	};
 	const peerParticipant = contactToParticipant(contact);
 	return {
-		client: new ExpensesClient(expensesConfig.serverUrl),
+		client: new ExpensesClient(expensesConfig.serverUrl, {
+			...(expensesConfig.apiToken ? { apiToken: expensesConfig.apiToken } : {}),
+		}),
 		config,
 		self,
 		members: [self, peerParticipant],

--- a/packages/cli/src/lib/expenses-client.ts
+++ b/packages/cli/src/lib/expenses-client.ts
@@ -1,0 +1,76 @@
+export class ExpensesClientError extends Error {
+	constructor(
+		public readonly status: number,
+		message: string,
+		public readonly code = "EXPENSE_SERVER_ERROR",
+	) {
+		super(message);
+		this.name = "ExpensesClientError";
+	}
+}
+
+export class ExpensesClient {
+	constructor(private readonly baseUrl: string) {}
+
+	createGroup(body: Record<string, unknown>): Promise<Record<string, unknown>> {
+		return this.post("/v1/groups", body);
+	}
+
+	logExpense(body: Record<string, unknown>): Promise<Record<string, unknown>> {
+		return this.post("/v1/expenses", body);
+	}
+
+	getBalance(groupId: string): Promise<Record<string, unknown>> {
+		return this.get(`/v1/groups/${encodeURIComponent(groupId)}/balance`);
+	}
+
+	getHistory(groupId: string): Promise<Record<string, unknown>> {
+		return this.get(`/v1/groups/${encodeURIComponent(groupId)}/history`);
+	}
+
+	createSettlement(
+		groupId: string,
+		body: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		return this.post(`/v1/groups/${encodeURIComponent(groupId)}/settlements`, body);
+	}
+
+	private async get(path: string): Promise<Record<string, unknown>> {
+		return this.request("GET", path);
+	}
+
+	private async post(
+		path: string,
+		body: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		return this.request("POST", path, body);
+	}
+
+	private async request(
+		method: "GET" | "POST",
+		path: string,
+		body?: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		const response = await fetch(`${this.baseUrl.replace(/\/$/, "")}${path}`, {
+			method,
+			...(body
+				? {
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(body),
+					}
+				: {}),
+		});
+		const data = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+		if (!response.ok) {
+			const error = data.error as { code?: unknown; message?: unknown } | undefined;
+			throw new ExpensesClientError(
+				response.status,
+				typeof error?.message === "string"
+					? error.message
+					: `Expense server returned ${response.status}`,
+				typeof error?.code === "string" ? error.code : "EXPENSE_SERVER_ERROR",
+			);
+		}
+		return data;
+	}
+}

--- a/packages/cli/src/lib/expenses-client.ts
+++ b/packages/cli/src/lib/expenses-client.ts
@@ -10,7 +10,10 @@ export class ExpensesClientError extends Error {
 }
 
 export class ExpensesClient {
-	constructor(private readonly baseUrl: string) {}
+	constructor(
+		private readonly baseUrl: string,
+		private readonly options: { apiToken?: string } = {},
+	) {}
 
 	createGroup(body: Record<string, unknown>): Promise<Record<string, unknown>> {
 		return this.post("/v1/groups", body);
@@ -53,9 +56,12 @@ export class ExpensesClient {
 	): Promise<Record<string, unknown>> {
 		const response = await fetch(`${this.baseUrl.replace(/\/$/, "")}${path}`, {
 			method,
+			headers: {
+				...(this.options.apiToken ? { authorization: `Bearer ${this.options.apiToken}` } : {}),
+				...(body ? { "content-type": "application/json" } : {}),
+			},
 			...(body
 				? {
-						headers: { "content-type": "application/json" },
 						body: JSON.stringify(body),
 					}
 				: {}),

--- a/packages/cli/src/lib/expenses-config.ts
+++ b/packages/cli/src/lib/expenses-config.ts
@@ -8,18 +8,21 @@ import { resolveConfigPath, resolveDataDir, validateConfigPathInDataDir } from "
 export interface ExpensesConfig {
 	serverUrl: string;
 	settlementAddress?: `0x${string}`;
+	apiToken?: string;
 }
 
 interface StoredExpensesYaml {
 	expenses?: {
 		server_url?: string;
 		settlement_address?: string;
+		api_token?: string;
 	};
 }
 
 export async function readExpensesConfig(opts: GlobalOptions): Promise<ExpensesConfig> {
 	const envServerUrl = process.env.TAP_EXPENSES_SERVER_URL;
 	const envSettlementAddress = process.env.TAP_EXPENSES_SETTLEMENT_ADDRESS;
+	const envApiToken = process.env.TAP_EXPENSES_API_TOKEN;
 	const dataDir = resolveDataDir(opts);
 	const configPath = resolveConfigPath(opts, dataDir);
 	validateConfigPathInDataDir(opts, configPath, dataDir);
@@ -29,11 +32,13 @@ export async function readExpensesConfig(opts: GlobalOptions): Promise<ExpensesC
 		throw new Error("Expense server URL is not configured. Run: tap expenses setup --server <url>");
 	}
 	const settlementAddress = envSettlementAddress ?? yaml.expenses?.settlement_address;
+	const apiToken = envApiToken ?? yaml.expenses?.api_token;
 	return {
 		serverUrl: normalizeExpensesServerUrl(serverUrl),
 		...(settlementAddress
 			? { settlementAddress: normalizeExpenseSettlementAddress(settlementAddress) }
 			: {}),
+		...(apiToken ? { apiToken: normalizeExpenseApiToken(apiToken) } : {}),
 	};
 }
 
@@ -55,6 +60,7 @@ export async function writeExpensesConfig(
 		...(config.settlementAddress
 			? { settlement_address: normalizeExpenseSettlementAddress(config.settlementAddress) }
 			: {}),
+		...(config.apiToken ? { api_token: normalizeExpenseApiToken(config.apiToken) } : {}),
 	};
 	await writeFileAtomic(configPath, YAML.stringify(yaml));
 	return { path: configPath };
@@ -73,6 +79,14 @@ export function normalizeExpenseSettlementAddress(value: string): `0x${string}` 
 		throw new Error(`Invalid settlement address: ${value}`);
 	}
 	return value as `0x${string}`;
+}
+
+export function normalizeExpenseApiToken(value: string): string {
+	const token = value.trim();
+	if (token.length < 8) {
+		throw new Error("Expense API token must be at least 8 characters");
+	}
+	return token;
 }
 
 async function readStoredYaml(configPath: string): Promise<StoredExpensesYaml> {

--- a/packages/cli/src/lib/expenses-config.ts
+++ b/packages/cli/src/lib/expenses-config.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import YAML from "yaml";
+import type { GlobalOptions } from "../types.js";
+import { writeFileAtomic } from "./atomic-write.js";
+import { resolveConfigPath, resolveDataDir, validateConfigPathInDataDir } from "./config-loader.js";
+
+export interface ExpensesConfig {
+	serverUrl: string;
+	settlementAddress?: `0x${string}`;
+}
+
+interface StoredExpensesYaml {
+	expenses?: {
+		server_url?: string;
+		settlement_address?: string;
+	};
+}
+
+export async function readExpensesConfig(opts: GlobalOptions): Promise<ExpensesConfig> {
+	const envServerUrl = process.env.TAP_EXPENSES_SERVER_URL;
+	const envSettlementAddress = process.env.TAP_EXPENSES_SETTLEMENT_ADDRESS;
+	const dataDir = resolveDataDir(opts);
+	const configPath = resolveConfigPath(opts, dataDir);
+	validateConfigPathInDataDir(opts, configPath, dataDir);
+	const yaml = await readStoredYaml(configPath);
+	const serverUrl = envServerUrl ?? yaml.expenses?.server_url;
+	if (serverUrl === undefined) {
+		throw new Error("Expense server URL is not configured. Run: tap expenses setup --server <url>");
+	}
+	const settlementAddress = envSettlementAddress ?? yaml.expenses?.settlement_address;
+	return {
+		serverUrl: normalizeExpensesServerUrl(serverUrl),
+		...(settlementAddress
+			? { settlementAddress: normalizeExpenseSettlementAddress(settlementAddress) }
+			: {}),
+	};
+}
+
+export async function writeExpensesConfig(
+	opts: GlobalOptions,
+	config: ExpensesConfig,
+): Promise<{ path: string }> {
+	const dataDir = resolveDataDir(opts);
+	const configPath = resolveConfigPath(opts, dataDir);
+	validateConfigPathInDataDir(opts, configPath, dataDir);
+	if (!existsSync(configPath)) {
+		throw new Error(`Config file not found at ${configPath}. Run 'tap init' first.`);
+	}
+	const yaml = (YAML.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>) ?? {};
+	const expenses = typeof yaml.expenses === "object" && yaml.expenses !== null ? yaml.expenses : {};
+	yaml.expenses = {
+		...(expenses as Record<string, unknown>),
+		server_url: normalizeExpensesServerUrl(config.serverUrl),
+		...(config.settlementAddress
+			? { settlement_address: normalizeExpenseSettlementAddress(config.settlementAddress) }
+			: {}),
+	};
+	await writeFileAtomic(configPath, YAML.stringify(yaml));
+	return { path: configPath };
+}
+
+export function normalizeExpensesServerUrl(value: string): string {
+	const parsed = new URL(value);
+	if (!["http:", "https:"].includes(parsed.protocol)) {
+		throw new Error("Expense server URL must use http or https");
+	}
+	return parsed.toString().replace(/\/$/, "");
+}
+
+export function normalizeExpenseSettlementAddress(value: string): `0x${string}` {
+	if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
+		throw new Error(`Invalid settlement address: ${value}`);
+	}
+	return value as `0x${string}`;
+}
+
+async function readStoredYaml(configPath: string): Promise<StoredExpensesYaml> {
+	if (!existsSync(configPath)) {
+		return {};
+	}
+	return (YAML.parse(await readFile(configPath, "utf-8")) as StoredExpensesYaml) ?? {};
+}

--- a/packages/cli/test/expenses.test.ts
+++ b/packages/cli/test/expenses.test.ts
@@ -1,0 +1,164 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import YAML from "yaml";
+import {
+	InMemoryExpenseStore,
+	createExpenseHttpServer,
+	createExpenseLedger,
+} from "../../expense-server/src/index.js";
+import { runCli } from "./helpers/run-cli.js";
+
+describe("tap expenses commands", () => {
+	let tempRoot: string;
+	let dataDir: string;
+	let server: ReturnType<typeof createExpenseHttpServer> | undefined;
+	let serverUrl: string;
+
+	beforeEach(async () => {
+		tempRoot = await mkdtemp(join(tmpdir(), "tap-expenses-"));
+		dataDir = join(tempRoot, "agent");
+		await mkdir(dataDir, { recursive: true });
+		await writeFile(
+			join(dataDir, "config.yaml"),
+			[
+				"agent_id: 1",
+				"chain: eip155:8453",
+				"ows:",
+				"  wallet: demo-wallet",
+				"  api_key: ows_key_demo",
+			].join("\n"),
+			"utf-8",
+		);
+		await writeFile(
+			join(dataDir, "contacts.json"),
+			JSON.stringify({
+				contacts: [
+					{
+						connectionId: "conn-bob",
+						peerAgentId: 2,
+						peerChain: "eip155:8453",
+						peerOwnerAddress: "0x2222222222222222222222222222222222222222",
+						peerDisplayName: "Bob",
+						peerAgentAddress: "0x2222222222222222222222222222222222222222",
+						permissions: {
+							grantedByMe: { version: "tap-grants/v1", updatedAt: "", grants: [] },
+							grantedByPeer: { version: "tap-grants/v1", updatedAt: "", grants: [] },
+						},
+						establishedAt: "2026-04-23T00:00:00.000Z",
+						lastContactAt: "2026-04-23T00:00:00.000Z",
+						status: "active",
+					},
+				],
+			}),
+			"utf-8",
+		);
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		server = createExpenseHttpServer({ ledger });
+		serverUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+	});
+
+	afterEach(async () => {
+		await server?.stop();
+		server = undefined;
+		await rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("sets up the server URL and settlement address", async () => {
+		const result = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"setup",
+			"--server",
+			serverUrl,
+			"--settlement-address",
+			"0x1111111111111111111111111111111111111111",
+		]);
+
+		expect(result.exitCode).toBe(0);
+		const output = JSON.parse(result.stdout) as { data: { server_url: string } };
+		expect(output.data.server_url).toBe(serverUrl);
+		const yaml = YAML.parse(await readFile(join(dataDir, "config.yaml"), "utf-8")) as {
+			expenses?: { server_url?: string; settlement_address?: string };
+		};
+		expect(yaml.expenses?.server_url).toBe(serverUrl);
+		expect(yaml.expenses?.settlement_address).toBe("0x1111111111111111111111111111111111111111");
+	});
+
+	it("creates a group, logs an expense, reads balance/history, and creates settlement", async () => {
+		await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"setup",
+			"--server",
+			serverUrl,
+			"--settlement-address",
+			"0x1111111111111111111111111111111111111111",
+		]);
+
+		const group = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"group",
+			"create",
+			"Bob",
+		]);
+		expect(group.exitCode).toBe(0);
+		expect(JSON.parse(group.stdout).data.group_id).toBe("expgrp_eip155_8453_1_eip155_8453_2");
+
+		const logged = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"log",
+			"Bob",
+			"45",
+			"groceries",
+			"--category",
+			"household",
+			"--idempotency-key",
+			"groceries-1",
+		]);
+		expect(logged.exitCode).toBe(0);
+		expect(JSON.parse(logged.stdout).data.amount).toBe("45");
+
+		const balance = await runCli(["--data-dir", dataDir, "--json", "expenses", "balance", "Bob"]);
+		expect(balance.exitCode).toBe(0);
+		expect(JSON.parse(balance.stdout).data.shares).toContainEqual({
+			agent_id: 2,
+			chain: "eip155:8453",
+			net_amount: "-22.5",
+		});
+
+		const history = await runCli(["--data-dir", dataDir, "--json", "expenses", "history", "Bob"]);
+		expect(history.exitCode).toBe(0);
+		expect(JSON.parse(history.stdout).data.expenses).toHaveLength(1);
+
+		const settlement = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"settle",
+			"Bob",
+			"--idempotency-key",
+			"settle-1",
+		]);
+		expect(settlement.exitCode).toBe(0);
+		expect(JSON.parse(settlement.stdout).data).toMatchObject({
+			debtor_agent_id: 2,
+			creditor_agent_id: 1,
+			amount: "22.5",
+			chain: "eip155:8453",
+			to_address: "0x1111111111111111111111111111111111111111",
+		});
+	});
+});

--- a/packages/cli/test/expenses.test.ts
+++ b/packages/cli/test/expenses.test.ts
@@ -88,6 +88,43 @@ describe("tap expenses commands", () => {
 		expect(yaml.expenses?.settlement_address).toBe("0x1111111111111111111111111111111111111111");
 	});
 
+	it("stores and uses the expense server API token", async () => {
+		await server?.stop();
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		server = createExpenseHttpServer({ ledger, apiToken: "secret-token" });
+		serverUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+
+		const setup = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"setup",
+			"--server",
+			serverUrl,
+			"--api-token",
+			"secret-token",
+		]);
+		expect(setup.exitCode).toBe(0);
+
+		const group = await runCli([
+			"--data-dir",
+			dataDir,
+			"--json",
+			"expenses",
+			"group",
+			"create",
+			"Bob",
+		]);
+		expect(group.exitCode).toBe(0);
+		expect(JSON.parse(group.stdout).data.group_id).toBe("expgrp_eip155_8453_1_eip155_8453_2");
+
+		const yaml = YAML.parse(await readFile(join(dataDir, "config.yaml"), "utf-8")) as {
+			expenses?: { api_token?: string };
+		};
+		expect(yaml.expenses?.api_token).toBe("secret-token");
+	});
+
 	it("creates a group, logs an expense, reads balance/history, and creates settlement", async () => {
 		await runCli([
 			"--data-dir",

--- a/packages/expense-server/package.json
+++ b/packages/expense-server/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "trusted-agents-expense-server",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"tap-expense-server": "./dist/bin.js"
+	},
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@trustedagents/app-expenses": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^25.3.3",
+		"typescript": "^5.7.0",
+		"vitest": "^3.0.0"
+	}
+}

--- a/packages/expense-server/src/bin.ts
+++ b/packages/expense-server/src/bin.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { InMemoryExpenseStore, createExpenseHttpServer, createExpenseLedger } from "./index.js";
+
+const host = process.env.EXPENSE_SERVER_HOST ?? "127.0.0.1";
+const port = Number.parseInt(process.env.EXPENSE_SERVER_PORT ?? "8787", 10);
+if (!Number.isInteger(port) || port < 0 || port > 65535) {
+	throw new Error(
+		`EXPENSE_SERVER_PORT must be between 0 and 65535, got ${process.env.EXPENSE_SERVER_PORT}`,
+	);
+}
+
+const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+const server = createExpenseHttpServer({ ledger });
+const url = await server.listen({ host, port });
+process.stdout.write(`tap expense server listening on ${url}\n`);
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+	process.on(signal, () => {
+		void server.stop().then(() => process.exit(0));
+	});
+}

--- a/packages/expense-server/src/bin.ts
+++ b/packages/expense-server/src/bin.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { InMemoryExpenseStore, createExpenseHttpServer, createExpenseLedger } from "./index.js";
+import { resolve } from "node:path";
+import { FileExpenseStore, createExpenseHttpServer, createExpenseLedger } from "./index.js";
 
 const host = process.env.EXPENSE_SERVER_HOST ?? "127.0.0.1";
 const port = Number.parseInt(process.env.EXPENSE_SERVER_PORT ?? "8787", 10);
@@ -9,13 +10,23 @@ if (!Number.isInteger(port) || port < 0 || port > 65535) {
 	);
 }
 
-const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
-const server = createExpenseHttpServer({ ledger });
+const apiToken = process.env.EXPENSE_SERVER_API_TOKEN?.trim();
+if (!apiToken && !isLoopbackHost(host)) {
+	throw new Error("EXPENSE_SERVER_API_TOKEN is required when binding outside loopback");
+}
+
+const dataFile = resolve(process.env.EXPENSE_SERVER_DATA_FILE ?? "expense-ledger.json");
+const ledger = createExpenseLedger({ store: new FileExpenseStore(dataFile) });
+const server = createExpenseHttpServer({ ledger, ...(apiToken ? { apiToken } : {}) });
 const url = await server.listen({ host, port });
-process.stdout.write(`tap expense server listening on ${url}\n`);
+process.stdout.write(`tap expense server listening on ${url}\nledger: ${dataFile}\n`);
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
 	process.on(signal, () => {
 		void server.stop().then(() => process.exit(0));
 	});
+}
+
+function isLoopbackHost(value: string): boolean {
+	return value === "localhost" || value === "127.0.0.1" || value === "::1";
 }

--- a/packages/expense-server/src/errors.ts
+++ b/packages/expense-server/src/errors.ts
@@ -1,0 +1,28 @@
+export class ExpenseServerError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly code: string,
+		message: string,
+	) {
+		super(message);
+		this.name = "ExpenseServerError";
+	}
+}
+
+export function badRequest(message: string, code = "INVALID_REQUEST"): ExpenseServerError {
+	return new ExpenseServerError(400, code, message);
+}
+
+export function unauthenticated(
+	message = "Missing or invalid expense API token",
+): ExpenseServerError {
+	return new ExpenseServerError(401, "UNAUTHENTICATED", message);
+}
+
+export function notFound(message: string, code = "NOT_FOUND"): ExpenseServerError {
+	return new ExpenseServerError(404, code, message);
+}
+
+export function conflict(message: string, code = "CONFLICT"): ExpenseServerError {
+	return new ExpenseServerError(409, code, message);
+}

--- a/packages/expense-server/src/http.ts
+++ b/packages/expense-server/src/http.ts
@@ -1,0 +1,126 @@
+import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { ExpenseLedger } from "./ledger.js";
+import type {
+	CreateExpenseGroupInput,
+	CreateSettlementIntentInput,
+	LogExpenseInput,
+} from "./types.js";
+
+export interface ExpenseHttpServer {
+	listen(options: { host: string; port: number }): Promise<string>;
+	stop(): Promise<void>;
+}
+
+export function createExpenseHttpServer(options: { ledger: ExpenseLedger }): ExpenseHttpServer {
+	const server = createServer((req, res) => {
+		void route(options.ledger, req, res).catch((error: unknown) => {
+			const message = error instanceof Error ? error.message : String(error);
+			sendJson(res, 500, { error: { code: "INTERNAL_ERROR", message } });
+		});
+	});
+
+	return {
+		listen: async ({ host, port }) => {
+			await new Promise<void>((resolve, reject) => {
+				server.once("error", reject);
+				server.listen(port, host, () => {
+					server.off("error", reject);
+					resolve();
+				});
+			});
+			const address = server.address() as AddressInfo;
+			return `http://${address.address}:${address.port}`;
+		},
+		stop: async () => {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		},
+	};
+}
+
+async function route(
+	ledger: ExpenseLedger,
+	req: IncomingMessage,
+	res: ServerResponse,
+): Promise<void> {
+	const method = req.method ?? "GET";
+	const path = new URL(req.url ?? "/", "http://localhost").pathname;
+
+	if (method === "GET" && path === "/health") {
+		sendJson(res, 200, { status: "ok" });
+		return;
+	}
+
+	if (method === "POST" && path === "/v1/groups") {
+		sendJson(res, 200, await ledger.createGroup((await readJson(req)) as CreateExpenseGroupInput));
+		return;
+	}
+
+	if (method === "POST" && path === "/v1/expenses") {
+		sendJson(res, 200, await ledger.logExpense((await readJson(req)) as LogExpenseInput));
+		return;
+	}
+
+	const balanceMatch = /^\/v1\/groups\/([^/]+)\/balance$/.exec(path);
+	if (method === "GET" && balanceMatch?.[1]) {
+		sendJson(res, 200, await ledger.getBalance(decodeURIComponent(balanceMatch[1])));
+		return;
+	}
+
+	const historyMatch = /^\/v1\/groups\/([^/]+)\/history$/.exec(path);
+	if (method === "GET" && historyMatch?.[1]) {
+		sendJson(res, 200, await ledger.listHistory(decodeURIComponent(historyMatch[1])));
+		return;
+	}
+
+	const settlementMatch = /^\/v1\/groups\/([^/]+)\/settlements$/.exec(path);
+	if (method === "POST" && settlementMatch?.[1]) {
+		const body = (await readJson(req)) as Record<string, unknown>;
+		sendJson(
+			res,
+			200,
+			await ledger.createSettlementIntent({
+				...body,
+				groupId: decodeURIComponent(settlementMatch[1]),
+			} as CreateSettlementIntentInput),
+		);
+		return;
+	}
+
+	sendJson(res, 404, { error: { code: "NOT_FOUND", message: "Route not found" } });
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let body = "";
+		req.setEncoding("utf8");
+		req.on("data", (chunk: string) => {
+			body += chunk;
+			if (body.length > 1024 * 1024) {
+				req.destroy();
+				reject(new Error("Request body too large"));
+			}
+		});
+		req.on("end", () => {
+			if (!body) {
+				resolve({});
+				return;
+			}
+			try {
+				resolve(JSON.parse(body));
+			} catch {
+				reject(new Error("Invalid JSON body"));
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+	const data = JSON.stringify(body);
+	res.writeHead(status, {
+		"content-type": "application/json",
+		"content-length": Buffer.byteLength(data),
+	});
+	res.end(data);
+}

--- a/packages/expense-server/src/http.ts
+++ b/packages/expense-server/src/http.ts
@@ -1,22 +1,29 @@
+import { timingSafeEqual } from "node:crypto";
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { ExpenseServerError, badRequest, unauthenticated } from "./errors.js";
 import type { ExpenseLedger } from "./ledger.js";
-import type {
-	CreateExpenseGroupInput,
-	CreateSettlementIntentInput,
-	LogExpenseInput,
-} from "./types.js";
+import {
+	parseCreateGroupInput,
+	parseCreateSettlementIntentInput,
+	parseLogExpenseInput,
+} from "./validation.js";
 
 export interface ExpenseHttpServer {
 	listen(options: { host: string; port: number }): Promise<string>;
 	stop(): Promise<void>;
 }
 
-export function createExpenseHttpServer(options: { ledger: ExpenseLedger }): ExpenseHttpServer {
+export function createExpenseHttpServer(options: {
+	ledger: ExpenseLedger;
+	apiToken?: string;
+}): ExpenseHttpServer {
 	const server = createServer((req, res) => {
-		void route(options.ledger, req, res).catch((error: unknown) => {
-			const message = error instanceof Error ? error.message : String(error);
-			sendJson(res, 500, { error: { code: "INTERNAL_ERROR", message } });
+		void route(options.ledger, options.apiToken, req, res).catch((error: unknown) => {
+			const normalized = normalizeError(error);
+			sendJson(res, normalized.status, {
+				error: { code: normalized.code, message: normalized.message },
+			});
 		});
 	});
 
@@ -30,16 +37,20 @@ export function createExpenseHttpServer(options: { ledger: ExpenseLedger }): Exp
 				});
 			});
 			const address = server.address() as AddressInfo;
-			return `http://${address.address}:${address.port}`;
+			const displayHost = address.family === "IPv6" ? `[${address.address}]` : address.address;
+			return `http://${displayHost}:${address.port}`;
 		},
 		stop: async () => {
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
 		},
 	};
 }
 
 async function route(
 	ledger: ExpenseLedger,
+	apiToken: string | undefined,
 	req: IncomingMessage,
 	res: ServerResponse,
 ): Promise<void> {
@@ -51,13 +62,15 @@ async function route(
 		return;
 	}
 
+	authorize(req, apiToken);
+
 	if (method === "POST" && path === "/v1/groups") {
-		sendJson(res, 200, await ledger.createGroup((await readJson(req)) as CreateExpenseGroupInput));
+		sendJson(res, 200, await ledger.createGroup(parseCreateGroupInput(await readJson(req))));
 		return;
 	}
 
 	if (method === "POST" && path === "/v1/expenses") {
-		sendJson(res, 200, await ledger.logExpense((await readJson(req)) as LogExpenseInput));
+		sendJson(res, 200, await ledger.logExpense(parseLogExpenseInput(await readJson(req))));
 		return;
 	}
 
@@ -75,19 +88,31 @@ async function route(
 
 	const settlementMatch = /^\/v1\/groups\/([^/]+)\/settlements$/.exec(path);
 	if (method === "POST" && settlementMatch?.[1]) {
-		const body = (await readJson(req)) as Record<string, unknown>;
 		sendJson(
 			res,
 			200,
-			await ledger.createSettlementIntent({
-				...body,
-				groupId: decodeURIComponent(settlementMatch[1]),
-			} as CreateSettlementIntentInput),
+			await ledger.createSettlementIntent(
+				parseCreateSettlementIntentInput(
+					decodeURIComponent(settlementMatch[1]),
+					await readJson(req),
+				),
+			),
 		);
 		return;
 	}
 
 	sendJson(res, 404, { error: { code: "NOT_FOUND", message: "Route not found" } });
+}
+
+function authorize(req: IncomingMessage, apiToken: string | undefined): void {
+	if (!apiToken) {
+		return;
+	}
+	const authorization = req.headers.authorization;
+	const token = authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : "";
+	if (!constantTimeEqual(token, apiToken)) {
+		throw unauthenticated();
+	}
 }
 
 async function readJson(req: IncomingMessage): Promise<unknown> {
@@ -98,7 +123,7 @@ async function readJson(req: IncomingMessage): Promise<unknown> {
 			body += chunk;
 			if (body.length > 1024 * 1024) {
 				req.destroy();
-				reject(new Error("Request body too large"));
+				reject(badRequest("Request body too large"));
 			}
 		});
 		req.on("end", () => {
@@ -109,11 +134,24 @@ async function readJson(req: IncomingMessage): Promise<unknown> {
 			try {
 				resolve(JSON.parse(body));
 			} catch {
-				reject(new Error("Invalid JSON body"));
+				reject(badRequest("Invalid JSON body"));
 			}
 		});
 		req.on("error", reject);
 	});
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+	const leftBuffer = Buffer.from(left);
+	const rightBuffer = Buffer.from(right);
+	return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function normalizeError(error: unknown): ExpenseServerError {
+	if (error instanceof ExpenseServerError) {
+		return error;
+	}
+	return new ExpenseServerError(500, "INTERNAL_ERROR", "Internal server error");
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {

--- a/packages/expense-server/src/index.ts
+++ b/packages/expense-server/src/index.ts
@@ -1,4 +1,6 @@
+export * from "./errors.js";
 export * from "./http.js";
 export * from "./ledger.js";
 export * from "./store.js";
 export * from "./types.js";
+export * from "./validation.js";

--- a/packages/expense-server/src/index.ts
+++ b/packages/expense-server/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./http.js";
+export * from "./ledger.js";
+export * from "./store.js";
+export * from "./types.js";

--- a/packages/expense-server/src/ledger.ts
+++ b/packages/expense-server/src/ledger.ts
@@ -11,6 +11,7 @@ import {
 	formatUsdcMinor,
 	parseUsdcAmount,
 } from "@trustedagents/app-expenses";
+import { conflict, notFound } from "./errors.js";
 import type { ExpenseStore } from "./store.js";
 import type {
 	CreateExpenseGroupInput,
@@ -69,6 +70,9 @@ class DefaultExpenseLedger implements ExpenseLedger {
 		const group =
 			(await this.store.getGroup(groupId)) ??
 			(await this.createGroup({ members: input.participants, chain: input.creator.chain }));
+		assertSameMembers(group.members, input.participants);
+		assertMember(group.members, input.creator, "creator");
+		assertMember(group.members, input.paidBy, "paidBy");
 		const amountMinor = parseUsdcAmount(input.amount);
 		const timestamp = this.now().toISOString();
 		const expense: ExpenseRecord = {
@@ -135,18 +139,40 @@ class DefaultExpenseLedger implements ExpenseLedger {
 		const debtorShare = minBy(balance.shares, (share) => BigInt(share.netMinor));
 		const creditorShare = maxBy(balance.shares, (share) => BigInt(share.netMinor));
 		if (!debtorShare || !creditorShare) {
-			throw new Error("Cannot settle an empty group");
+			throw conflict("Cannot settle an empty group", "EMPTY_GROUP");
 		}
 
 		const debtorAmount = -BigInt(debtorShare.netMinor);
 		const creditorAmount = BigInt(creditorShare.netMinor);
 		if (debtorAmount <= 0n || creditorAmount <= 0n) {
-			throw new Error("Group has no outstanding balance to settle");
+			throw conflict("Group has no outstanding balance to settle", "NO_OUTSTANDING_BALANCE");
 		}
 
 		const amountMinor = debtorAmount < creditorAmount ? debtorAmount : creditorAmount;
 		const debtor = findMember(group.members, debtorShare);
 		const creditor = findMember(group.members, creditorShare);
+		if (
+			input.reason === "threshold" &&
+			group.settlementThresholdMinor !== undefined &&
+			amountMinor < BigInt(group.settlementThresholdMinor)
+		) {
+			throw conflict(
+				"Settlement amount is below the group threshold",
+				"SETTLEMENT_BELOW_THRESHOLD",
+			);
+		}
+
+		const openSettlement = await this.findOpenSettlement(
+			input.groupId,
+			debtor,
+			creditor,
+			amountMinor,
+			group.chain,
+		);
+		if (openSettlement) {
+			return openSettlement;
+		}
+
 		const createdAt = this.now();
 		const expiresAt =
 			input.expiresAt ?? new Date(createdAt.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
@@ -173,20 +199,63 @@ class DefaultExpenseLedger implements ExpenseLedger {
 	private async requireGroup(groupId: string): Promise<ExpenseGroup> {
 		const group = await this.store.getGroup(groupId);
 		if (!group) {
-			throw new Error(`Expense group not found: ${groupId}`);
+			throw notFound(`Expense group not found: ${groupId}`, "EXPENSE_GROUP_NOT_FOUND");
 		}
 		return group;
+	}
+
+	private async findOpenSettlement(
+		groupId: string,
+		debtor: ExpenseParticipant,
+		creditor: ExpenseParticipant,
+		amountMinor: bigint,
+		chain: string,
+	): Promise<ExpenseSettlementIntent | undefined> {
+		return (await this.store.listSettlements(groupId)).find(
+			(settlement) =>
+				(settlement.status === "pending" || settlement.status === "submitted") &&
+				settlement.chain === chain &&
+				settlement.amountMinor === amountMinor.toString() &&
+				sameMember(settlement.debtor, debtor) &&
+				sameMember(settlement.creditor, creditor),
+		);
 	}
 }
 
 function assertMembers(members: ExpenseParticipant[]): void {
 	if (members.length < 2) {
-		throw new Error("Expense groups require at least two members");
+		throw conflict("Expense groups require at least two members", "INVALID_GROUP_MEMBERS");
+	}
+}
+
+function assertSameMembers(expected: ExpenseParticipant[], actual: ExpenseParticipant[]): void {
+	if (
+		expected.length !== actual.length ||
+		expected.some((member) => !actual.some((candidate) => sameMember(member, candidate)))
+	) {
+		throw conflict("Expense participants must match group members", "GROUP_MEMBERS_MISMATCH");
+	}
+}
+
+function assertMember(
+	members: ExpenseParticipant[],
+	participant: ExpenseParticipant,
+	field: string,
+): void {
+	if (!members.some((member) => sameMember(member, participant))) {
+		throw conflict(`${field} must be a group member`, "GROUP_MEMBER_REQUIRED");
 	}
 }
 
 function memberKey(member: Pick<ExpenseParticipant, "agentId" | "chain">): string {
 	return `${member.chain}:${member.agentId}`;
+}
+
+function sameMember(
+	left: Pick<ExpenseParticipant, "agentId" | "chain">,
+	right: Pick<ExpenseParticipant, "agentId" | "chain">,
+): boolean {
+	return left.agentId === right.agentId && left.chain === right.chain;
 }
 
 function addToMap(map: Map<string, bigint>, key: string, delta: bigint): void {

--- a/packages/expense-server/src/ledger.ts
+++ b/packages/expense-server/src/ledger.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from "node:crypto";
+import {
+	type ExpenseBalance,
+	type ExpenseBalanceShare,
+	type ExpenseGroup,
+	type ExpenseParticipant,
+	type ExpenseRecord,
+	type ExpenseSettlementIntent,
+	buildEqualSplits,
+	deriveExpenseGroupId,
+	formatUsdcMinor,
+	parseUsdcAmount,
+} from "@trustedagents/app-expenses";
+import type { ExpenseStore } from "./store.js";
+import type {
+	CreateExpenseGroupInput,
+	CreateSettlementIntentInput,
+	ExpenseHistory,
+	LogExpenseInput,
+} from "./types.js";
+
+export interface ExpenseLedger {
+	createGroup(input: CreateExpenseGroupInput): Promise<ExpenseGroup>;
+	logExpense(input: LogExpenseInput): Promise<ExpenseRecord>;
+	getBalance(groupId: string): Promise<ExpenseBalance>;
+	listHistory(groupId: string): Promise<ExpenseHistory>;
+	createSettlementIntent(input: CreateSettlementIntentInput): Promise<ExpenseSettlementIntent>;
+}
+
+export function createExpenseLedger(options: {
+	store: ExpenseStore;
+	now?: () => Date;
+}): ExpenseLedger {
+	return new DefaultExpenseLedger(options.store, options.now ?? (() => new Date()));
+}
+
+class DefaultExpenseLedger implements ExpenseLedger {
+	constructor(
+		private readonly store: ExpenseStore,
+		private readonly now: () => Date,
+	) {}
+
+	async createGroup(input: CreateExpenseGroupInput): Promise<ExpenseGroup> {
+		assertMembers(input.members);
+		const timestamp = this.now().toISOString();
+		const groupId = deriveExpenseGroupId(input.members);
+		return await this.store.upsertGroup({
+			groupId,
+			members: input.members,
+			split: "equal",
+			chain: input.chain,
+			asset: "usdc",
+			...(input.settlementThreshold
+				? { settlementThresholdMinor: parseUsdcAmount(input.settlementThreshold).toString() }
+				: {}),
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		});
+	}
+
+	async logExpense(input: LogExpenseInput): Promise<ExpenseRecord> {
+		assertMembers(input.participants);
+		const groupId = input.groupId ?? deriveExpenseGroupId(input.participants);
+		const existing = await this.store.findExpenseByIdempotencyKey(groupId, input.idempotencyKey);
+		if (existing) {
+			return existing;
+		}
+
+		const group =
+			(await this.store.getGroup(groupId)) ??
+			(await this.createGroup({ members: input.participants, chain: input.creator.chain }));
+		const amountMinor = parseUsdcAmount(input.amount);
+		const timestamp = this.now().toISOString();
+		const expense: ExpenseRecord = {
+			eventId: `expev_${randomUUID()}`,
+			groupId: group.groupId,
+			idempotencyKey: input.idempotencyKey,
+			creator: input.creator,
+			paidBy: input.paidBy,
+			amountMinor: amountMinor.toString(),
+			asset: "usdc",
+			expenseCurrency: "USD",
+			description: input.description,
+			...(input.category ? { category: input.category } : {}),
+			occurredAt: input.occurredAt ?? timestamp,
+			participants: input.participants,
+			splits: buildEqualSplits(amountMinor, input.participants),
+			createdAt: timestamp,
+		};
+
+		return await this.store.appendExpense(expense);
+	}
+
+	async getBalance(groupId: string): Promise<ExpenseBalance> {
+		const group = await this.requireGroup(groupId);
+		const totals = new Map<string, bigint>();
+		for (const member of group.members) {
+			totals.set(memberKey(member), 0n);
+		}
+
+		for (const expense of await this.store.listExpenses(groupId)) {
+			addToMap(totals, memberKey(expense.paidBy), BigInt(expense.amountMinor));
+			for (const split of expense.splits) {
+				addToMap(totals, `${split.chain}:${split.agentId}`, -BigInt(split.amountMinor));
+			}
+		}
+
+		const shares: ExpenseBalanceShare[] = group.members.map((member) => ({
+			agentId: member.agentId,
+			chain: member.chain,
+			netMinor: (totals.get(memberKey(member)) ?? 0n).toString(),
+		}));
+
+		return { groupId, asset: "usdc", shares };
+	}
+
+	async listHistory(groupId: string): Promise<ExpenseHistory> {
+		await this.requireGroup(groupId);
+		return { groupId, expenses: await this.store.listExpenses(groupId) };
+	}
+
+	async createSettlementIntent(
+		input: CreateSettlementIntentInput,
+	): Promise<ExpenseSettlementIntent> {
+		const existing = await this.store.findSettlementByIdempotencyKey(
+			input.groupId,
+			input.idempotencyKey,
+		);
+		if (existing) {
+			return existing;
+		}
+
+		const group = await this.requireGroup(input.groupId);
+		const balance = await this.getBalance(input.groupId);
+		const debtorShare = minBy(balance.shares, (share) => BigInt(share.netMinor));
+		const creditorShare = maxBy(balance.shares, (share) => BigInt(share.netMinor));
+		if (!debtorShare || !creditorShare) {
+			throw new Error("Cannot settle an empty group");
+		}
+
+		const debtorAmount = -BigInt(debtorShare.netMinor);
+		const creditorAmount = BigInt(creditorShare.netMinor);
+		if (debtorAmount <= 0n || creditorAmount <= 0n) {
+			throw new Error("Group has no outstanding balance to settle");
+		}
+
+		const amountMinor = debtorAmount < creditorAmount ? debtorAmount : creditorAmount;
+		const debtor = findMember(group.members, debtorShare);
+		const creditor = findMember(group.members, creditorShare);
+		const createdAt = this.now();
+		const expiresAt =
+			input.expiresAt ?? new Date(createdAt.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
+		const settlement: ExpenseSettlementIntent = {
+			intentId: `expset_${randomUUID()}`,
+			groupId: input.groupId,
+			debtor,
+			creditor,
+			amountMinor: amountMinor.toString(),
+			asset: "usdc",
+			chain: group.chain,
+			...(debtor.address ? { fromAddress: debtor.address } : {}),
+			...(creditor.address ? { toAddress: creditor.address } : {}),
+			reason: input.reason,
+			status: "pending",
+			idempotencyKey: input.idempotencyKey,
+			createdAt: createdAt.toISOString(),
+			expiresAt,
+		};
+
+		return await this.store.appendSettlement(settlement);
+	}
+
+	private async requireGroup(groupId: string): Promise<ExpenseGroup> {
+		const group = await this.store.getGroup(groupId);
+		if (!group) {
+			throw new Error(`Expense group not found: ${groupId}`);
+		}
+		return group;
+	}
+}
+
+function assertMembers(members: ExpenseParticipant[]): void {
+	if (members.length < 2) {
+		throw new Error("Expense groups require at least two members");
+	}
+}
+
+function memberKey(member: Pick<ExpenseParticipant, "agentId" | "chain">): string {
+	return `${member.chain}:${member.agentId}`;
+}
+
+function addToMap(map: Map<string, bigint>, key: string, delta: bigint): void {
+	map.set(key, (map.get(key) ?? 0n) + delta);
+}
+
+function findMember(
+	members: ExpenseParticipant[],
+	share: Pick<ExpenseBalanceShare, "agentId" | "chain">,
+): ExpenseParticipant {
+	const member = members.find(
+		(candidate) => candidate.agentId === share.agentId && candidate.chain === share.chain,
+	);
+	if (!member) {
+		throw new Error(`Expense group member missing for ${share.chain}:${share.agentId}`);
+	}
+	return member;
+}
+
+function minBy<T>(items: T[], score: (item: T) => bigint): T | undefined {
+	return items.reduce<T | undefined>(
+		(best, item) => (best === undefined || score(item) < score(best) ? item : best),
+		undefined,
+	);
+}
+
+function maxBy<T>(items: T[], score: (item: T) => bigint): T | undefined {
+	return items.reduce<T | undefined>(
+		(best, item) => (best === undefined || score(item) > score(best) ? item : best),
+		undefined,
+	);
+}
+
+export function settlementAmountDecimal(intent: ExpenseSettlementIntent): string {
+	return formatUsdcMinor(intent.amountMinor);
+}

--- a/packages/expense-server/src/store.ts
+++ b/packages/expense-server/src/store.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import type {
 	ExpenseGroup,
 	ExpenseRecord,
@@ -18,6 +21,7 @@ export interface ExpenseStore {
 		groupId: string,
 		idempotencyKey: string,
 	): Promise<ExpenseSettlementIntent | undefined>;
+	listSettlements(groupId: string): Promise<ExpenseSettlementIntent[]>;
 	appendSettlement(settlement: ExpenseSettlementIntent): Promise<ExpenseSettlementIntent>;
 	snapshot(): Promise<ExpenseStoreSnapshot>;
 }
@@ -67,6 +71,10 @@ export class InMemoryExpenseStore implements ExpenseStore {
 		);
 	}
 
+	async listSettlements(groupId: string): Promise<ExpenseSettlementIntent[]> {
+		return [...(this.settlements.get(groupId) ?? [])];
+	}
+
 	async appendSettlement(settlement: ExpenseSettlementIntent): Promise<ExpenseSettlementIntent> {
 		const settlements = this.settlements.get(settlement.groupId) ?? [];
 		settlements.push(settlement);
@@ -81,4 +89,135 @@ export class InMemoryExpenseStore implements ExpenseStore {
 			settlements: [...this.settlements.values()].flat(),
 		};
 	}
+}
+
+export class FileExpenseStore implements ExpenseStore {
+	private readonly writeMutex = new AsyncMutex();
+
+	constructor(private readonly filePath: string) {}
+
+	async getGroup(groupId: string): Promise<ExpenseGroup | undefined> {
+		return (await this.load()).groups.find((group) => group.groupId === groupId);
+	}
+
+	async upsertGroup(group: ExpenseGroup): Promise<ExpenseGroup> {
+		return await this.writeMutex.runExclusive(async () => {
+			const snapshot = await this.load();
+			const index = snapshot.groups.findIndex((candidate) => candidate.groupId === group.groupId);
+			if (index >= 0) {
+				const existing = snapshot.groups[index]!;
+				const next = { ...existing, ...group, createdAt: existing.createdAt };
+				snapshot.groups[index] = next;
+				await this.save(snapshot);
+				return next;
+			}
+			snapshot.groups.push(group);
+			await this.save(snapshot);
+			return group;
+		});
+	}
+
+	async listExpenses(groupId: string): Promise<ExpenseRecord[]> {
+		return (await this.load()).expenses.filter((expense) => expense.groupId === groupId);
+	}
+
+	async findExpenseByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseRecord | undefined> {
+		return (await this.load()).expenses.find(
+			(expense) => expense.groupId === groupId && expense.idempotencyKey === idempotencyKey,
+		);
+	}
+
+	async appendExpense(expense: ExpenseRecord): Promise<ExpenseRecord> {
+		return await this.writeMutex.runExclusive(async () => {
+			const snapshot = await this.load();
+			snapshot.expenses.push(expense);
+			await this.save(snapshot);
+			return expense;
+		});
+	}
+
+	async findSettlementByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseSettlementIntent | undefined> {
+		return (await this.load()).settlements.find(
+			(settlement) =>
+				settlement.groupId === groupId && settlement.idempotencyKey === idempotencyKey,
+		);
+	}
+
+	async listSettlements(groupId: string): Promise<ExpenseSettlementIntent[]> {
+		return (await this.load()).settlements.filter((settlement) => settlement.groupId === groupId);
+	}
+
+	async appendSettlement(settlement: ExpenseSettlementIntent): Promise<ExpenseSettlementIntent> {
+		return await this.writeMutex.runExclusive(async () => {
+			const snapshot = await this.load();
+			snapshot.settlements.push(settlement);
+			await this.save(snapshot);
+			return settlement;
+		});
+	}
+
+	async snapshot(): Promise<ExpenseStoreSnapshot> {
+		const snapshot = await this.load();
+		return {
+			groups: [...snapshot.groups],
+			expenses: [...snapshot.expenses],
+			settlements: [...snapshot.settlements],
+		};
+	}
+
+	private async load(): Promise<ExpenseStoreSnapshot> {
+		try {
+			const parsed = JSON.parse(
+				await readFile(this.filePath, "utf-8"),
+			) as Partial<ExpenseStoreSnapshot>;
+			return {
+				groups: Array.isArray(parsed.groups) ? parsed.groups : [],
+				expenses: Array.isArray(parsed.expenses) ? parsed.expenses : [],
+				settlements: Array.isArray(parsed.settlements) ? parsed.settlements : [],
+			};
+		} catch (err: unknown) {
+			if (isEnoent(err)) {
+				return { groups: [], expenses: [], settlements: [] };
+			}
+			throw err;
+		}
+	}
+
+	private async save(snapshot: ExpenseStoreSnapshot): Promise<void> {
+		await mkdir(dirname(this.filePath), { recursive: true, mode: 0o700 });
+		const tempPath = `${this.filePath}.${randomUUID()}.tmp`;
+		await writeFile(tempPath, JSON.stringify(snapshot, null, "\t"), {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+		await rename(tempPath, this.filePath);
+	}
+}
+
+class AsyncMutex {
+	private current = Promise.resolve();
+
+	async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+		const previous = this.current;
+		let release!: () => void;
+		this.current = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await fn();
+		} finally {
+			release();
+		}
+	}
+}
+
+function isEnoent(err: unknown): boolean {
+	return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
 }

--- a/packages/expense-server/src/store.ts
+++ b/packages/expense-server/src/store.ts
@@ -1,0 +1,84 @@
+import type {
+	ExpenseGroup,
+	ExpenseRecord,
+	ExpenseSettlementIntent,
+} from "@trustedagents/app-expenses";
+import type { ExpenseStoreSnapshot } from "./types.js";
+
+export interface ExpenseStore {
+	getGroup(groupId: string): Promise<ExpenseGroup | undefined>;
+	upsertGroup(group: ExpenseGroup): Promise<ExpenseGroup>;
+	listExpenses(groupId: string): Promise<ExpenseRecord[]>;
+	findExpenseByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseRecord | undefined>;
+	appendExpense(expense: ExpenseRecord): Promise<ExpenseRecord>;
+	findSettlementByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseSettlementIntent | undefined>;
+	appendSettlement(settlement: ExpenseSettlementIntent): Promise<ExpenseSettlementIntent>;
+	snapshot(): Promise<ExpenseStoreSnapshot>;
+}
+
+export class InMemoryExpenseStore implements ExpenseStore {
+	private readonly groups = new Map<string, ExpenseGroup>();
+	private readonly expenses = new Map<string, ExpenseRecord[]>();
+	private readonly settlements = new Map<string, ExpenseSettlementIntent[]>();
+
+	async getGroup(groupId: string): Promise<ExpenseGroup | undefined> {
+		return this.groups.get(groupId);
+	}
+
+	async upsertGroup(group: ExpenseGroup): Promise<ExpenseGroup> {
+		const existing = this.groups.get(group.groupId);
+		const next = existing ? { ...existing, ...group, createdAt: existing.createdAt } : group;
+		this.groups.set(group.groupId, next);
+		return next;
+	}
+
+	async listExpenses(groupId: string): Promise<ExpenseRecord[]> {
+		return [...(this.expenses.get(groupId) ?? [])];
+	}
+
+	async findExpenseByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseRecord | undefined> {
+		return (this.expenses.get(groupId) ?? []).find(
+			(expense) => expense.idempotencyKey === idempotencyKey,
+		);
+	}
+
+	async appendExpense(expense: ExpenseRecord): Promise<ExpenseRecord> {
+		const expenses = this.expenses.get(expense.groupId) ?? [];
+		expenses.push(expense);
+		this.expenses.set(expense.groupId, expenses);
+		return expense;
+	}
+
+	async findSettlementByIdempotencyKey(
+		groupId: string,
+		idempotencyKey: string,
+	): Promise<ExpenseSettlementIntent | undefined> {
+		return (this.settlements.get(groupId) ?? []).find(
+			(settlement) => settlement.idempotencyKey === idempotencyKey,
+		);
+	}
+
+	async appendSettlement(settlement: ExpenseSettlementIntent): Promise<ExpenseSettlementIntent> {
+		const settlements = this.settlements.get(settlement.groupId) ?? [];
+		settlements.push(settlement);
+		this.settlements.set(settlement.groupId, settlements);
+		return settlement;
+	}
+
+	async snapshot(): Promise<ExpenseStoreSnapshot> {
+		return {
+			groups: [...this.groups.values()],
+			expenses: [...this.expenses.values()].flat(),
+			settlements: [...this.settlements.values()].flat(),
+		};
+	}
+}

--- a/packages/expense-server/src/types.ts
+++ b/packages/expense-server/src/types.ts
@@ -1,0 +1,43 @@
+import type {
+	ExpenseGroup,
+	ExpenseParticipant,
+	ExpenseRecord,
+	ExpenseSettlementIntent,
+	ExpenseSettlementReason,
+} from "@trustedagents/app-expenses";
+
+export interface CreateExpenseGroupInput {
+	members: ExpenseParticipant[];
+	chain: string;
+	settlementThreshold?: string;
+}
+
+export interface LogExpenseInput {
+	groupId?: string;
+	idempotencyKey: string;
+	creator: ExpenseParticipant;
+	paidBy: ExpenseParticipant;
+	amount: string;
+	description: string;
+	category?: string;
+	participants: ExpenseParticipant[];
+	occurredAt?: string;
+}
+
+export interface CreateSettlementIntentInput {
+	groupId: string;
+	reason: ExpenseSettlementReason;
+	idempotencyKey: string;
+	expiresAt?: string;
+}
+
+export interface ExpenseHistory {
+	groupId: string;
+	expenses: ExpenseRecord[];
+}
+
+export interface ExpenseStoreSnapshot {
+	groups: ExpenseGroup[];
+	expenses: ExpenseRecord[];
+	settlements: ExpenseSettlementIntent[];
+}

--- a/packages/expense-server/src/validation.ts
+++ b/packages/expense-server/src/validation.ts
@@ -1,0 +1,138 @@
+import { type ExpenseParticipant, parseUsdcAmount } from "@trustedagents/app-expenses";
+import { badRequest } from "./errors.js";
+import type {
+	CreateExpenseGroupInput,
+	CreateSettlementIntentInput,
+	LogExpenseInput,
+} from "./types.js";
+
+const SETTLEMENT_REASONS = new Set(["manual", "threshold", "schedule"]);
+
+export function parseCreateGroupInput(input: unknown): CreateExpenseGroupInput {
+	const record = asRecord(input);
+	const members = parseParticipants(record.members, "members");
+	return {
+		members,
+		chain: parseNonEmptyString(record.chain, "chain"),
+		...(record.settlementThreshold !== undefined
+			? { settlementThreshold: parseUsdcDecimal(record.settlementThreshold, "settlementThreshold") }
+			: {}),
+	};
+}
+
+export function parseLogExpenseInput(input: unknown): LogExpenseInput {
+	const record = asRecord(input);
+	const amount = parseUsdcDecimal(record.amount, "amount");
+	return {
+		...(record.groupId !== undefined
+			? { groupId: parseNonEmptyString(record.groupId, "groupId") }
+			: {}),
+		idempotencyKey: parseNonEmptyString(record.idempotencyKey, "idempotencyKey"),
+		creator: parseParticipant(record.creator, "creator"),
+		paidBy: parseParticipant(record.paidBy, "paidBy"),
+		amount,
+		description: parseNonEmptyString(record.description, "description"),
+		...(record.category !== undefined
+			? { category: parseNonEmptyString(record.category, "category") }
+			: {}),
+		participants: parseParticipants(record.participants, "participants"),
+		...(record.occurredAt !== undefined
+			? { occurredAt: parseDateString(record.occurredAt, "occurredAt") }
+			: {}),
+	};
+}
+
+export function parseCreateSettlementIntentInput(
+	groupId: string,
+	input: unknown,
+): CreateSettlementIntentInput {
+	const record = asRecord(input);
+	const reason = parseNonEmptyString(record.reason, "reason");
+	if (!SETTLEMENT_REASONS.has(reason)) {
+		throw badRequest("reason must be manual, threshold, or schedule");
+	}
+	return {
+		groupId,
+		reason: reason as CreateSettlementIntentInput["reason"],
+		idempotencyKey: parseNonEmptyString(record.idempotencyKey, "idempotencyKey"),
+		...(record.expiresAt !== undefined
+			? { expiresAt: parseDateString(record.expiresAt, "expiresAt") }
+			: {}),
+	};
+}
+
+function parseParticipants(value: unknown, field: string): ExpenseParticipant[] {
+	if (!Array.isArray(value)) {
+		throw badRequest(`${field} must be an array`);
+	}
+	if (value.length < 2) {
+		throw badRequest(`${field} must include at least two participants`);
+	}
+	return value.map((participant, index) => parseParticipant(participant, `${field}[${index}]`));
+}
+
+function parseParticipant(value: unknown, field: string): ExpenseParticipant {
+	const record = asRecord(value, `${field} must be an object`);
+	const agentId = parseAgentId(record.agentId, `${field}.agentId`);
+	const chain = parseNonEmptyString(record.chain, `${field}.chain`);
+	return {
+		agentId,
+		chain,
+		...(record.displayName !== undefined
+			? { displayName: parseNonEmptyString(record.displayName, `${field}.displayName`) }
+			: {}),
+		...(record.address !== undefined
+			? { address: parseEthereumAddress(record.address, `${field}.address`) }
+			: {}),
+	};
+}
+
+function asRecord(
+	value: unknown,
+	message = "request body must be an object",
+): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw badRequest(message);
+	}
+	return value as Record<string, unknown>;
+}
+
+function parseAgentId(value: unknown, field: string): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+		throw badRequest(`${field} must be a non-negative integer`);
+	}
+	return value;
+}
+
+function parseNonEmptyString(value: unknown, field: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw badRequest(`${field} must be a non-empty string`);
+	}
+	return value.trim();
+}
+
+function parseUsdcDecimal(value: unknown, field: string): string {
+	const amount = parseNonEmptyString(value, field);
+	try {
+		parseUsdcAmount(amount);
+		return amount;
+	} catch (err: unknown) {
+		throw badRequest(err instanceof Error ? err.message : `${field} must be a valid USDC amount`);
+	}
+}
+
+function parseDateString(value: unknown, field: string): string {
+	const text = parseNonEmptyString(value, field);
+	if (Number.isNaN(new Date(text).getTime())) {
+		throw badRequest(`${field} must be a valid ISO date string`);
+	}
+	return text;
+}
+
+function parseEthereumAddress(value: unknown, field: string): `0x${string}` {
+	const text = parseNonEmptyString(value, field);
+	if (!/^0x[0-9a-fA-F]{40}$/.test(text)) {
+		throw badRequest(`${field} must be an Ethereum address`);
+	}
+	return text as `0x${string}`;
+}

--- a/packages/expense-server/test/http.test.ts
+++ b/packages/expense-server/test/http.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	FileExpenseStore,
 	InMemoryExpenseStore,
 	createExpenseHttpServer,
 	createExpenseLedger,
@@ -19,10 +23,15 @@ const bob = {
 };
 
 let server: ReturnType<typeof createExpenseHttpServer> | undefined;
+let tempRoot: string | undefined;
 
 afterEach(async () => {
 	await server?.stop();
 	server = undefined;
+	if (tempRoot) {
+		await rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
 });
 
 describe("expense HTTP API", () => {
@@ -69,6 +78,76 @@ describe("expense HTTP API", () => {
 		expect(settlement.debtor.agentId).toBe(2);
 		expect(settlement.amountMinor).toBe("22500000");
 	});
+
+	it("requires bearer auth when configured", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		server = createExpenseHttpServer({ ledger, apiToken: "secret-token" });
+		const baseUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+
+		const health = await fetch(`${baseUrl}/health`);
+		expect(health.status).toBe(200);
+
+		const unauthenticated = await fetch(`${baseUrl}/v1/groups`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ members: [alice, bob], chain: "eip155:8453" }),
+		});
+		expect(unauthenticated.status).toBe(401);
+		expect(await unauthenticated.json()).toEqual({
+			error: { code: "UNAUTHENTICATED", message: "Missing or invalid expense API token" },
+		});
+
+		const group = await postJson(
+			`${baseUrl}/v1/groups`,
+			{ members: [alice, bob], chain: "eip155:8453" },
+			"secret-token",
+		);
+		expect(group.groupId).toBe("expgrp_eip155_8453_1_eip155_8453_2");
+	});
+
+	it("returns 400 for invalid request bodies", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		server = createExpenseHttpServer({ ledger });
+		const baseUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+
+		const response = await fetch(`${baseUrl}/v1/groups`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ members: "not-an-array", chain: "eip155:8453" }),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: { code: "INVALID_REQUEST", message: "members must be an array" },
+		});
+	});
+
+	it("persists ledger state with the file store", async () => {
+		tempRoot = await mkdtemp(join(tmpdir(), "tap-expense-store-"));
+		const storePath = join(tempRoot, "ledger.json");
+		const firstLedger = createExpenseLedger({ store: new FileExpenseStore(storePath) });
+		const group = await firstLedger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
+		await firstLedger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			participants: [alice, bob],
+		});
+
+		const secondLedger = createExpenseLedger({ store: new FileExpenseStore(storePath) });
+		const history = await secondLedger.listHistory(group.groupId);
+		const balance = await secondLedger.getBalance(group.groupId);
+
+		expect(history.expenses).toHaveLength(1);
+		expect(balance.shares).toContainEqual({
+			agentId: 2,
+			chain: "eip155:8453",
+			netMinor: "-22500000",
+		});
+	});
 });
 
 async function getJson(url: string): Promise<Record<string, unknown>> {
@@ -80,10 +159,14 @@ async function getJson(url: string): Promise<Record<string, unknown>> {
 async function postJson(
 	url: string,
 	body: Record<string, unknown>,
+	apiToken?: string,
 ): Promise<Record<string, unknown>> {
 	const response = await fetch(url, {
 		method: "POST",
-		headers: { "content-type": "application/json" },
+		headers: {
+			"content-type": "application/json",
+			...(apiToken ? { authorization: `Bearer ${apiToken}` } : {}),
+		},
 		body: JSON.stringify(body),
 	});
 	expect(response.ok).toBe(true);

--- a/packages/expense-server/test/http.test.ts
+++ b/packages/expense-server/test/http.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	InMemoryExpenseStore,
+	createExpenseHttpServer,
+	createExpenseLedger,
+} from "../src/index.js";
+
+const alice = {
+	agentId: 1,
+	chain: "eip155:8453",
+	displayName: "Alice",
+	address: "0x1111111111111111111111111111111111111111",
+};
+const bob = {
+	agentId: 2,
+	chain: "eip155:8453",
+	displayName: "Bob",
+	address: "0x2222222222222222222222222222222222222222",
+};
+
+let server: ReturnType<typeof createExpenseHttpServer> | undefined;
+
+afterEach(async () => {
+	await server?.stop();
+	server = undefined;
+});
+
+describe("expense HTTP API", () => {
+	it("creates a group, logs an expense, reads balance and history, and creates settlement", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		server = createExpenseHttpServer({ ledger });
+		const baseUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+
+		const health = await getJson(`${baseUrl}/health`);
+		expect(health).toEqual({ status: "ok" });
+
+		const group = await postJson(`${baseUrl}/v1/groups`, {
+			members: [alice, bob],
+			chain: "eip155:8453",
+		});
+		expect(group.groupId).toBe("expgrp_eip155_8453_1_eip155_8453_2");
+
+		const expense = await postJson(`${baseUrl}/v1/expenses`, {
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			category: "household",
+			participants: [alice, bob],
+		});
+		expect(expense.description).toBe("groceries");
+
+		const balance = await getJson(`${baseUrl}/v1/groups/${group.groupId}/balance`);
+		expect(balance.shares).toContainEqual({
+			agentId: 2,
+			chain: "eip155:8453",
+			netMinor: "-22500000",
+		});
+
+		const history = await getJson(`${baseUrl}/v1/groups/${group.groupId}/history`);
+		expect(history.expenses).toHaveLength(1);
+
+		const settlement = await postJson(`${baseUrl}/v1/groups/${group.groupId}/settlements`, {
+			reason: "manual",
+			idempotencyKey: "settle-1",
+		});
+		expect(settlement.debtor.agentId).toBe(2);
+		expect(settlement.amountMinor).toBe("22500000");
+	});
+});
+
+async function getJson(url: string): Promise<Record<string, unknown>> {
+	const response = await fetch(url);
+	expect(response.ok).toBe(true);
+	return (await response.json()) as Record<string, unknown>;
+}
+
+async function postJson(
+	url: string,
+	body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	expect(response.ok).toBe(true);
+	return (await response.json()) as Record<string, unknown>;
+}

--- a/packages/expense-server/test/ledger.test.ts
+++ b/packages/expense-server/test/ledger.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryExpenseStore, createExpenseLedger } from "../src/index.js";
+
+const alice = {
+	agentId: 1,
+	chain: "eip155:8453",
+	displayName: "Alice",
+	address: "0x1111111111111111111111111111111111111111" as const,
+};
+const bob = {
+	agentId: 2,
+	chain: "eip155:8453",
+	displayName: "Bob",
+	address: "0x2222222222222222222222222222222222222222" as const,
+};
+
+describe("expense ledger", () => {
+	it("logs an equal-split expense and computes net balances", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+
+		const group = await ledger.createGroup({
+			members: [alice, bob],
+			chain: "eip155:8453",
+		});
+		const expense = await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			category: "household",
+			participants: [alice, bob],
+			occurredAt: "2026-04-23T20:00:00.000Z",
+		});
+
+		expect(expense.amountMinor).toBe("45000000");
+		expect(expense.splits).toEqual([
+			{ agentId: 1, chain: "eip155:8453", amountMinor: "22500000" },
+			{ agentId: 2, chain: "eip155:8453", amountMinor: "22500000" },
+		]);
+
+		const balance = await ledger.getBalance(group.groupId);
+		expect(balance.shares).toEqual([
+			{ agentId: 1, chain: "eip155:8453", netMinor: "22500000" },
+			{ agentId: 2, chain: "eip155:8453", netMinor: "-22500000" },
+		]);
+	});
+
+	it("returns the existing expense for duplicate idempotency keys", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		const group = await ledger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
+
+		const first = await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "same-key",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			participants: [alice, bob],
+		});
+		const second = await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "same-key",
+			creator: alice,
+			paidBy: alice,
+			amount: "99",
+			description: "ignored duplicate",
+			participants: [alice, bob],
+		});
+
+		expect(second).toEqual(first);
+		expect((await ledger.listHistory(group.groupId)).expenses).toHaveLength(1);
+	});
+
+	it("creates a settlement intent for the net debtor", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		const group = await ledger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
+		await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			participants: [alice, bob],
+		});
+
+		const settlement = await ledger.createSettlementIntent({
+			groupId: group.groupId,
+			reason: "manual",
+			idempotencyKey: "settle-1",
+		});
+
+		expect(settlement.debtor.agentId).toBe(2);
+		expect(settlement.creditor.agentId).toBe(1);
+		expect(settlement.amountMinor).toBe("22500000");
+		expect(settlement.chain).toBe("eip155:8453");
+		expect(settlement.toAddress).toBe(alice.address);
+	});
+});

--- a/packages/expense-server/test/ledger.test.ts
+++ b/packages/expense-server/test/ledger.test.ts
@@ -13,6 +13,12 @@ const bob = {
 	displayName: "Bob",
 	address: "0x2222222222222222222222222222222222222222" as const,
 };
+const carol = {
+	agentId: 3,
+	chain: "eip155:8453",
+	displayName: "Carol",
+	address: "0x3333333333333333333333333333333333333333" as const,
+};
 
 describe("expense ledger", () => {
 	it("logs an equal-split expense and computes net balances", async () => {
@@ -74,6 +80,23 @@ describe("expense ledger", () => {
 		expect((await ledger.listHistory(group.groupId)).expenses).toHaveLength(1);
 	});
 
+	it("rejects expenses whose participants do not match the existing group", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		const group = await ledger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
+
+		await expect(
+			ledger.logExpense({
+				groupId: group.groupId,
+				idempotencyKey: "wrong-members",
+				creator: alice,
+				paidBy: alice,
+				amount: "45",
+				description: "groceries",
+				participants: [alice, carol],
+			}),
+		).rejects.toThrow("Expense participants must match group members");
+	});
+
 	it("creates a settlement intent for the net debtor", async () => {
 		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
 		const group = await ledger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
@@ -98,5 +121,60 @@ describe("expense ledger", () => {
 		expect(settlement.amountMinor).toBe("22500000");
 		expect(settlement.chain).toBe("eip155:8453");
 		expect(settlement.toAddress).toBe(alice.address);
+	});
+
+	it("returns the existing pending settlement for the same net balance", async () => {
+		const store = new InMemoryExpenseStore();
+		const ledger = createExpenseLedger({ store });
+		const group = await ledger.createGroup({ members: [alice, bob], chain: "eip155:8453" });
+		await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			participants: [alice, bob],
+		});
+
+		const first = await ledger.createSettlementIntent({
+			groupId: group.groupId,
+			reason: "manual",
+			idempotencyKey: "settle-1",
+		});
+		const second = await ledger.createSettlementIntent({
+			groupId: group.groupId,
+			reason: "manual",
+			idempotencyKey: "settle-2",
+		});
+
+		expect(second).toEqual(first);
+		expect((await store.snapshot()).settlements).toHaveLength(1);
+	});
+
+	it("enforces threshold settlement minimums", async () => {
+		const ledger = createExpenseLedger({ store: new InMemoryExpenseStore() });
+		const group = await ledger.createGroup({
+			members: [alice, bob],
+			chain: "eip155:8453",
+			settlementThreshold: "30",
+		});
+		await ledger.logExpense({
+			groupId: group.groupId,
+			idempotencyKey: "groceries-1",
+			creator: alice,
+			paidBy: alice,
+			amount: "45",
+			description: "groceries",
+			participants: [alice, bob],
+		});
+
+		await expect(
+			ledger.createSettlementIntent({
+				groupId: group.groupId,
+				reason: "threshold",
+				idempotencyKey: "settle-threshold",
+			}),
+		).rejects.toThrow("Settlement amount is below the group threshold");
 	});
 });

--- a/packages/expense-server/tsconfig.json
+++ b/packages/expense-server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"composite": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/expense-server/vitest.config.ts
+++ b/packages/expense-server/vitest.config.ts
@@ -9,8 +9,6 @@ export default defineConfig({
 	},
 	resolve: {
 		alias: {
-			"trusted-agents-core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
-			"trusted-agents-sdk": path.resolve(import.meta.dirname, "../sdk/src/index.ts"),
 			"@trustedagents/app-expenses": path.resolve(
 				import.meta.dirname,
 				"../app-expenses/src/index.ts",

--- a/skills/trusted-agents/SKILL.md
+++ b/skills/trusted-agents/SKILL.md
@@ -399,7 +399,7 @@ In OpenClaw or Hermes plugin mode, use `tap_gateway transfer` with `asset`, `amo
 Shared expenses keep an off-chain tab with a connected peer and settle only the net balance in USDC. Expenses are recorded through the configured expense server; the server does not custody funds or broadcast transfers.
 
 ```bash
-tap expenses setup --server https://expenses.example.com --settlement-address 0x1111111111111111111111111111111111111111
+tap expenses setup --server https://expenses.example.com --api-token $EXPENSE_SERVER_API_TOKEN --settlement-address 0x1111111111111111111111111111111111111111
 tap expenses group create Bob --settle-threshold 25
 tap expenses log Bob 45 "groceries" --category household --idempotency-key groceries-2026-04-23
 tap expenses balance Bob
@@ -410,6 +410,8 @@ tap expenses settle Bob --idempotency-key settle-2026-week-17
 Flow: setup server -> create or auto-create peer group -> log expenses without on-chain transactions -> inspect net balance -> create settlement intent for one USDC transfer. Positive balances mean the agent is owed USDC; negative balances mean the agent owes USDC.
 
 Use `expense/settle` grants for automatic settlement policy. Do not reuse `transfer/request` grants for shared-expense settlement; shared expenses have their own ledger and netting context.
+
+The standalone expense server reads `EXPENSE_SERVER_DATA_FILE` for its durable ledger path and `EXPENSE_SERVER_API_TOKEN` for bearer authentication. Binding the server outside loopback requires `EXPENSE_SERVER_API_TOKEN`. Clients can configure the bearer token with `tap expenses setup --api-token` or `TAP_EXPENSES_API_TOKEN`.
 
 ## Meeting Scheduling
 

--- a/skills/trusted-agents/SKILL.md
+++ b/skills/trusted-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trusted-agents
-description: Operate a Trusted Agents Protocol agent with the `tap` CLI — install, onboard, connect to other agents, manage permissions, send messages, request funds, and schedule meetings. Use this skill whenever the user wants to work with TAP, set up an agent identity, connect agents, exchange grants, schedule meetings or dinners, check calendar availability, or do anything involving agent-to-agent communication or on-chain identity — even if they don't explicitly say "TAP." Also use this skill when the user mentions scheduling, meetings, dinners, calendar setup, or coordinating times with another agent. Also use inside OpenClaw Gateway or Hermes when the `tap_gateway` tool is available or when handling TAP notifications.
+description: Operate a Trusted Agents Protocol agent with the `tap` CLI — install, onboard, connect to other agents, manage permissions, send messages, request funds, track shared expenses, and schedule meetings. Use this skill whenever the user wants to work with TAP, set up an agent identity, connect agents, exchange grants, split bills, schedule meetings or dinners, check calendar availability, or do anything involving agent-to-agent communication or on-chain identity — even if they don't explicitly say "TAP." Also use this skill when the user mentions scheduling, meetings, dinners, shared expenses, splitting bills, calendar setup, or coordinating times with another agent. Also use inside OpenClaw Gateway or Hermes when the `tap_gateway` tool is available or when handling TAP notifications.
 ---
 
 # Trusted Agents Protocol
@@ -335,6 +335,7 @@ See `references/permissions-v1.md` for the full JSON spec with all fields and ad
 | `research` | Questions, information gathering |
 | `scheduling/request` | Meeting scheduling — propose, counter, accept, reject, cancel |
 | `transfer/request` | Value movement |
+| `expense/settle` | Automatic shared-expense settlement permission |
 | `permissions/request-grants` | Ask for permissions |
 
 ## Messages
@@ -392,6 +393,23 @@ Validation errors:
 - unknown chain or `usdc` on a chain without a configured USDC token
 
 In OpenClaw or Hermes plugin mode, use `tap_gateway transfer` with `asset`, `amount`, `toAddress`, and optionally `chain` (defaults to configured chain, must be CAIP-2).
+
+## Shared Expenses
+
+Shared expenses keep an off-chain tab with a connected peer and settle only the net balance in USDC. Expenses are recorded through the configured expense server; the server does not custody funds or broadcast transfers.
+
+```bash
+tap expenses setup --server https://expenses.example.com --settlement-address 0x1111111111111111111111111111111111111111
+tap expenses group create Bob --settle-threshold 25
+tap expenses log Bob 45 "groceries" --category household --idempotency-key groceries-2026-04-23
+tap expenses balance Bob
+tap expenses history Bob
+tap expenses settle Bob --idempotency-key settle-2026-week-17
+```
+
+Flow: setup server -> create or auto-create peer group -> log expenses without on-chain transactions -> inspect net balance -> create settlement intent for one USDC transfer. Positive balances mean the agent is owed USDC; negative balances mean the agent owes USDC.
+
+Use `expense/settle` grants for automatic settlement policy. Do not reuse `transfer/request` grants for shared-expense settlement; shared expenses have their own ledger and netting context.
 
 ## Meeting Scheduling
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "files": [],
   "references": [
-    { "path": "packages/core" }
+    { "path": "packages/core" },
+    { "path": "packages/app-expenses" },
+    { "path": "packages/expense-server" }
   ]
 }


### PR DESCRIPTION
Fixes #37.

Adds the shared expense ledger path for agents that already hold stablecoins: agents can log group expenses, publish shared-expense grants, compute net obligations, and settle only the final balance in USDC instead of putting every expense on-chain. The ledger server is centralized but hardened for the MVP with bearer-token auth on ledger routes, file-backed persistence by default, runtime request validation, member/invariant checks, and duplicate-settlement protection. CLI setup now accepts an API token and the Trusted Agents skill documents the server configuration.

Validated with `bun run lint`, `bun run typecheck`, `bun run build`, and `bun run test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new ledger/business logic and a new HTTP service plus CLI commands that compute and persist balances/settlement intents; mistakes could lead to incorrect netting or settlement instructions, though actual on-chain transfers remain out of scope.
> 
> **Overview**
> Adds a new shared-expense MVP that lets agents **log off-chain expenses, compute net USDC balances, and generate a settlement intent** rather than executing per-expense transfers.
> 
> Introduces `@trustedagents/app-expenses` for shared types, USDC amount parsing/formatting, equal-split math, deterministic group IDs, and `expense/settle` grant matching.
> 
> Adds a new `trusted-agents-expense-server` Node HTTP service with request validation, optional bearer-token auth, in-memory/file-backed persistence, idempotent expense + settlement intent creation, and balance/history endpoints; wires it into the workspace build/typecheck/test flow.
> 
> Extends the `tap` CLI with `tap expenses` commands (`setup`, `group create`, `log`, `balance`, `history`, `settle`) including config/env handling for server URL, API token, and settlement address, and updates TAP skill/docs/specs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a3ee8c5bd018aaacaef0811c1b0333e210fc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->